### PR TITLE
feat: add health factor validation to vault operations

### DIFF
--- a/contracts/vault-engine.clar
+++ b/contracts/vault-engine.clar
@@ -2,10 +2,21 @@
 (define-constant ERR_NO_VAULT u201)
 (define-constant ERR_INSUFFICIENT_COLLATERAL u202)
 (define-constant ERR_INSUFFICIENT_DEBT u203)
+(define-constant ERR_UNSAFE_HEALTH_FACTOR u204)
+
+(define-constant MIN-HEALTH-FACTOR u150)
+(define-constant ZERO-DEBT-HEALTH-FACTOR u1000000)
 
 (define-map vaults
   {owner: principal}
   {collateral: uint, debt: uint}
+)
+
+(define-private (calculate-health-factor (collateral uint) (debt uint))
+  (if (is-eq debt u0)
+    ZERO-DEBT-HEALTH-FACTOR
+    (/ (* collateral u100) debt)
+  )
 )
 
 (define-public (open-vault)
@@ -20,7 +31,7 @@
   (match (map-get? vaults {owner: tx-sender})
     vault
       (let ((new-collateral (+ (get collateral vault) amount)))
-        ;; TODO: transfer sBTC from user to vault
+        ;; TODO(sBTC): transfer sBTC from user to protocol custody vault
         (map-set vaults
           {owner: tx-sender}
           {collateral: new-collateral, debt: (get debt vault)}
@@ -34,12 +45,18 @@
 (define-public (mint (amount uint))
   (match (map-get? vaults {owner: tx-sender})
     vault
-      (let ((new-debt (+ (get debt vault) amount)))
-        ;; TODO: use oracle + collateral registry for health checks
+      (let (
+          (collateral (get collateral vault))
+          (new-debt (+ (get debt vault) amount))
+          (health-factor (calculate-health-factor (get collateral vault) (+ (get debt vault) amount)))
+        )
+        ;; Placeholder health check: collateral and debt are same-unit values for prototype only.
+        ;; TODO: use oracle + collateral registry + asset decimals for production risk checks.
+        (asserts! (>= health-factor MIN-HEALTH-FACTOR) (err ERR_UNSAFE_HEALTH_FACTOR))
         (try! (contract-call? .stablecoin-token mint amount tx-sender))
         (map-set vaults
           {owner: tx-sender}
-          {collateral: (get collateral vault), debt: new-debt}
+          {collateral: collateral, debt: new-debt}
         )
         (ok new-debt)
       )
@@ -68,12 +85,19 @@
     vault
       (begin
         (asserts! (>= (get collateral vault) amount) (err ERR_INSUFFICIENT_COLLATERAL))
-        (let ((new-collateral (- (get collateral vault) amount)))
-          ;; TODO: enforce health factor checks
-          ;; TODO: transfer sBTC back to user
+        (let (
+            (debt (get debt vault))
+            (new-collateral (- (get collateral vault) amount))
+            (health-factor (calculate-health-factor (- (get collateral vault) amount) (get debt vault)))
+          )
+          (if (is-eq debt u0)
+            true
+            (asserts! (>= health-factor MIN-HEALTH-FACTOR) (err ERR_UNSAFE_HEALTH_FACTOR))
+          )
+          ;; TODO(sBTC): transfer sBTC from protocol custody vault back to user
           (map-set vaults
             {owner: tx-sender}
-            {collateral: new-collateral, debt: (get debt vault)}
+            {collateral: new-collateral, debt: debt}
           )
           (ok new-collateral)
         )
@@ -84,9 +108,7 @@
 
 (define-read-only (get-health-factor (owner principal))
   (let ((vault (default-to {collateral: u0, debt: u0} (map-get? vaults {owner: owner}))))
-    (if (is-eq (get debt vault) u0)
-      u1000000
-      (/ (* (get collateral vault) u100) (get debt vault))
-    )
+    ;; Minimal placeholder ratio math, intentionally not using oracle pricing in prototype scope.
+    (calculate-health-factor (get collateral vault) (get debt vault))
   )
 )

--- a/tests/sse.test.ts
+++ b/tests/sse.test.ts
@@ -51,7 +51,7 @@ describe("stablecoin-token hardening", () => {
     expect(authorized.result).toBeOk(Cl.bool(true));
   });
 
-  it("allows mint and burn only via vault-engine and tracks total supply", () => {
+  it("runs vault lifecycle end-to-end and tracks total supply", () => {
     const accounts = simnet.getAccounts();
     const deployer = accounts.get("deployer");
     const wallet1 = accounts.get("wallet_1");
@@ -84,18 +84,18 @@ describe("stablecoin-token hardening", () => {
     result = simnet.callPublicFn(
       "vault-engine",
       "deposit-collateral",
-      [Cl.uint(1000)],
+      [Cl.uint(1200)],
       wallet1
     );
-    expect(result.result).toBeOk(Cl.uint(1000));
+    expect(result.result).toBeOk(Cl.uint(1200));
 
     result = simnet.callPublicFn(
       "vault-engine",
       "mint",
-      [Cl.uint(500)],
+      [Cl.uint(600)],
       wallet1
     );
-    expect(result.result).toBeOk(Cl.uint(500));
+    expect(result.result).toBeOk(Cl.uint(600));
 
     const totalSupplyAfterMint = simnet.callReadOnlyFn(
       "stablecoin-token",
@@ -103,7 +103,7 @@ describe("stablecoin-token hardening", () => {
       [],
       wallet1
     );
-    expect(totalSupplyAfterMint.result).toBeOk(Cl.uint(500));
+    expect(totalSupplyAfterMint.result).toBeOk(Cl.uint(600));
 
     const directBurn = simnet.callPublicFn(
       "stablecoin-token",
@@ -121,13 +121,21 @@ describe("stablecoin-token hardening", () => {
     );
     expect(result.result).toBeOk(Cl.bool(true));
 
+    result = simnet.callPublicFn(
+      "vault-engine",
+      "withdraw-collateral",
+      [Cl.uint(300)],
+      wallet1
+    );
+    expect(result.result).toBeOk(Cl.uint(900));
+
     const balance = simnet.callReadOnlyFn(
       "stablecoin-token",
       "get-balance",
       [Cl.principal(wallet1)],
       wallet1
     );
-    expect(balance.result).toBeOk(Cl.uint(300));
+    expect(balance.result).toBeOk(Cl.uint(400));
 
     const totalSupplyAfterBurn = simnet.callReadOnlyFn(
       "stablecoin-token",
@@ -135,6 +143,69 @@ describe("stablecoin-token hardening", () => {
       [],
       wallet1
     );
-    expect(totalSupplyAfterBurn.result).toBeOk(Cl.uint(300));
+    expect(totalSupplyAfterBurn.result).toBeOk(Cl.uint(400));
+
+    const health = simnet.callReadOnlyFn(
+      "vault-engine",
+      "get-health-factor",
+      [Cl.principal(wallet1)],
+      wallet1
+    );
+    expect(health.result).toBeUint(225);
+  });
+
+  it("rejects minting that would break minimum health factor", () => {
+    const accounts = simnet.getAccounts();
+    const deployer = accounts.get("deployer");
+    const wallet1 = accounts.get("wallet_1");
+
+    if (!deployer || !wallet1) {
+      throw new Error("Missing default simnet accounts");
+    }
+
+    const vaultEnginePrincipal = `${deployer}.vault-engine`;
+
+    let result = simnet.callPublicFn(
+      "stablecoin-token",
+      "set-vault-engine",
+      [Cl.principal(vaultEnginePrincipal)],
+      deployer
+    );
+    expect(result.result).toBeOk(Cl.bool(true));
+
+    result = simnet.callPublicFn("vault-engine", "open-vault", [], wallet1);
+    expect(result.result).toBeOk(Cl.bool(true));
+
+    result = simnet.callPublicFn(
+      "vault-engine",
+      "deposit-collateral",
+      [Cl.uint(1000)],
+      wallet1
+    );
+    expect(result.result).toBeOk(Cl.uint(1000));
+
+    result = simnet.callPublicFn(
+      "vault-engine",
+      "mint",
+      [Cl.uint(700)],
+      wallet1
+    );
+    expect(result.result).toBeErr(Cl.uint(204));
+
+    const balance = simnet.callReadOnlyFn(
+      "stablecoin-token",
+      "get-balance",
+      [Cl.principal(wallet1)],
+      wallet1
+    );
+    expect(balance.result).toBeOk(Cl.uint(0));
+
+    const totalSupply = simnet.callReadOnlyFn(
+      "stablecoin-token",
+      "get-total-supply",
+      [],
+      wallet1
+    );
+    expect(totalSupply.result).toBeOk(Cl.uint(0));
   });
 });


### PR DESCRIPTION
Add health factor calculation and validation to prevent unsafe vault positions. Implement minimum health factor threshold (150%) for mint and withdraw-collateral operations. Update test suite to verify health factor enforcement and adjust test values to maintain safe collateralization ratios.