### PR TITLE
feat: integrate DIA oracle with staleness validation and multi-oracle support

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -80,6 +80,20 @@ path = "contracts/price-oracle-stx-v3.clar"
 epoch = "3.1"
 depends_on = ["oracle-trait"]
 
+[contracts.dia-oracle-adapter]
+path = "contracts/dia-oracle-adapter.clar"
+epoch = "3.1"
+
+[contracts.price-oracle-dia-btc]
+path = "contracts/price-oracle-dia-btc.clar"
+epoch = "3.1"
+depends_on = ["oracle-trait", "dia-oracle-adapter"]
+
+[contracts.price-oracle-dia-stx]
+path = "contracts/price-oracle-dia-stx.clar"
+epoch = "3.1"
+depends_on = ["oracle-trait", "dia-oracle-adapter"]
+
 [contracts.sbtc-token-v3]
 path = "contracts/sbtc-token-v3.clar"
 epoch = "3.1"
@@ -121,7 +135,7 @@ depends_on = ["sip-010-trait", "stablecoin-engine-token-trait", "multi-asset-vau
 [contracts.multi-asset-vault-engine-v3]
 path = "contracts/multi-asset-vault-engine-v3.clar"
 epoch = "3.1"
-depends_on = ["sip-010-trait", "stablecoin-token-v3", "price-oracle-sbtc-v3", "price-oracle-stx-v3", "collateral-registry-v3", "stablecoin-factory-v3", "stablecoin-engine-token-trait", "sbtc-token-v3", "stx-token-v3"]
+depends_on = ["sip-010-trait", "stablecoin-token-v3", "price-oracle-sbtc-v3", "price-oracle-stx-v3", "price-oracle-dia-btc", "price-oracle-dia-stx", "collateral-registry-v3", "stablecoin-factory-v3", "stablecoin-engine-token-trait", "sbtc-token-v3", "stx-token-v3"]
 
 [contracts.xreserve-adapter-v3]
 path = "contracts/xreserve-adapter-v3.clar"

--- a/contracts/dia-oracle-adapter-testnet.clar
+++ b/contracts/dia-oracle-adapter-testnet.clar
@@ -1,0 +1,15 @@
+;; DIA Oracle Adapter (Testnet)
+;; ---
+;; Forwards get-value calls to the real DIA testnet contract.
+;; Deploy this as "dia-oracle-adapter" on testnet so the DIA wrapper
+;; oracles (price-oracle-dia-btc, price-oracle-dia-stx) resolve correctly.
+;;
+;; DIA Testnet: ST1S5ZGRZV5K4S9205RWPRTX9RGS9JV40KQMR4G1J.dia-oracle
+;; DIA Mainnet: SP1G48FZ4Y7JY8G2Z0N51QTCYGBQ6F4J43J77BQC0.dia-oracle
+
+(define-constant ERR_PAIR_NOT_FOUND u701)
+
+;; Forward to DIA testnet oracle
+(define-read-only (get-value (pair (string-ascii 20)))
+  (contract-call? 'ST1S5ZGRZV5K4S9205RWPRTX9RGS9JV40KQMR4G1J.dia-oracle get-value pair)
+)

--- a/contracts/dia-oracle-adapter.clar
+++ b/contracts/dia-oracle-adapter.clar
@@ -1,0 +1,49 @@
+;; DIA Oracle Adapter
+;; ---
+;; Local adapter that mirrors DIA's on-chain oracle interface.
+;; In simnet/devnet this acts as an owner-settable mock.
+;; For testnet/mainnet, deploy a version that forwards to the real DIA contract:
+;;   Testnet: ST1S5ZGRZV5K4S9205RWPRTX9RGS9JV40KQMR4G1J.dia-oracle
+;;   Mainnet: SP1G48FZ4Y7JY8G2Z0N51QTCYGBQ6F4J43J77BQC0.dia-oracle
+
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant ERR_UNAUTHORIZED u700)
+(define-constant ERR_PAIR_NOT_FOUND u701)
+
+;; Stores price data per pair string, e.g. "BTC/USD", "STX/USD"
+(define-map price-data
+  {pair: (string-ascii 20)}
+  {value: uint, timestamp: uint}
+)
+
+;; Owner-only: set price for a pair (simnet/devnet testing)
+(define-public (set-value (pair (string-ascii 20)) (new-value uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (map-set price-data
+      {pair: pair}
+      {value: new-value, timestamp: (unwrap-panic (get-stacks-block-info? time (- stacks-block-height u1)))}
+    )
+    (ok true)
+  )
+)
+
+;; Owner-only: set price with explicit timestamp (for staleness testing)
+(define-public (set-value-with-timestamp (pair (string-ascii 20)) (new-value uint) (ts uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (map-set price-data
+      {pair: pair}
+      {value: new-value, timestamp: ts}
+    )
+    (ok true)
+  )
+)
+
+;; Read-only: matches DIA oracle's get-value interface
+(define-read-only (get-value (pair (string-ascii 20)))
+  (match (map-get? price-data {pair: pair})
+    entry (ok entry)
+    (err ERR_PAIR_NOT_FOUND)
+  )
+)

--- a/contracts/multi-asset-vault-engine-v3.clar
+++ b/contracts/multi-asset-vault-engine-v3.clar
@@ -36,6 +36,8 @@
 ;; Known oracle IDs
 (define-constant ORACLE-SBTC u1)
 (define-constant ORACLE-STX u2)
+(define-constant ORACLE-DIA-BTC u3)
+(define-constant ORACLE-DIA-STX u4)
 
 ;; ============================================
 ;; Data Maps
@@ -79,7 +81,7 @@
 (define-public (register-asset-oracle (asset principal) (oracle-id uint))
   (begin
     (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
-    (asserts! (or (is-eq oracle-id ORACLE-SBTC) (is-eq oracle-id ORACLE-STX)) (err ERR_UNKNOWN_ORACLE))
+    (asserts! (or (is-eq oracle-id ORACLE-SBTC) (is-eq oracle-id ORACLE-STX) (is-eq oracle-id ORACLE-DIA-BTC) (is-eq oracle-id ORACLE-DIA-STX)) (err ERR_UNKNOWN_ORACLE))
     (map-set asset-oracle-id {asset: asset} {oracle-id: oracle-id})
     (ok true)
   )
@@ -101,7 +103,13 @@
     (unwrap-panic (contract-call? .price-oracle-sbtc-v3 get-price))
     (if (is-eq oracle-id ORACLE-STX)
       (unwrap-panic (contract-call? .price-oracle-stx-v3 get-price))
-      u0
+      (if (is-eq oracle-id ORACLE-DIA-BTC)
+        (unwrap-panic (contract-call? .price-oracle-dia-btc get-price))
+        (if (is-eq oracle-id ORACLE-DIA-STX)
+          (unwrap-panic (contract-call? .price-oracle-dia-stx get-price))
+          u0
+        )
+      )
     )
   )
 )

--- a/contracts/price-oracle-dia-btc.clar
+++ b/contracts/price-oracle-dia-btc.clar
@@ -1,0 +1,42 @@
+;; DIA-backed BTC/USD Price Oracle
+;; ---
+;; Implements oracle-trait by reading BTC/USD from the DIA oracle adapter.
+;; Includes configurable staleness guard -- rejects prices older than MAX_STALENESS seconds.
+
+(impl-trait .oracle-trait.oracle-trait)
+
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant ERR_UNAUTHORIZED u600)
+(define-constant ERR_STALE_PRICE u601)
+(define-constant ERR_NO_PRICE u602)
+(define-constant PAIR "BTC/USD")
+
+;; Default max staleness: 3600 seconds (1 hour)
+(define-data-var max-staleness uint u3600)
+
+;; Owner-only: tune staleness threshold
+(define-public (set-max-staleness (new-max uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (var-set max-staleness new-max)
+    (ok true)
+  )
+)
+
+(define-read-only (get-max-staleness)
+  (var-get max-staleness)
+)
+
+;; oracle-trait implementation
+(define-read-only (get-price)
+  (let (
+      (dia-data (unwrap! (contract-call? .dia-oracle-adapter get-value PAIR) (err ERR_NO_PRICE)))
+      (price-value (get value dia-data))
+      (price-ts (get timestamp dia-data))
+      (current-ts (unwrap! (get-stacks-block-info? time (- stacks-block-height u1)) (err ERR_NO_PRICE)))
+      (age (- current-ts price-ts))
+    )
+    (asserts! (<= age (var-get max-staleness)) (err ERR_STALE_PRICE))
+    (ok price-value)
+  )
+)

--- a/contracts/price-oracle-dia-stx.clar
+++ b/contracts/price-oracle-dia-stx.clar
@@ -1,0 +1,42 @@
+;; DIA-backed STX/USD Price Oracle
+;; ---
+;; Implements oracle-trait by reading STX/USD from the DIA oracle adapter.
+;; Includes configurable staleness guard -- rejects prices older than MAX_STALENESS seconds.
+
+(impl-trait .oracle-trait.oracle-trait)
+
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant ERR_UNAUTHORIZED u600)
+(define-constant ERR_STALE_PRICE u601)
+(define-constant ERR_NO_PRICE u602)
+(define-constant PAIR "STX/USD")
+
+;; Default max staleness: 3600 seconds (1 hour)
+(define-data-var max-staleness uint u3600)
+
+;; Owner-only: tune staleness threshold
+(define-public (set-max-staleness (new-max uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (var-set max-staleness new-max)
+    (ok true)
+  )
+)
+
+(define-read-only (get-max-staleness)
+  (var-get max-staleness)
+)
+
+;; oracle-trait implementation
+(define-read-only (get-price)
+  (let (
+      (dia-data (unwrap! (contract-call? .dia-oracle-adapter get-value PAIR) (err ERR_NO_PRICE)))
+      (price-value (get value dia-data))
+      (price-ts (get timestamp dia-data))
+      (current-ts (unwrap! (get-stacks-block-info? time (- stacks-block-height u1)) (err ERR_NO_PRICE)))
+      (age (- current-ts price-ts))
+    )
+    (asserts! (<= age (var-get max-staleness)) (err ERR_STALE_PRICE))
+    (ok price-value)
+  )
+)

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -99,6 +99,11 @@ plan:
             path: contracts/collateral-registry-v3.clar
             clarity-version: 3
         - emulated-contract-publish:
+            contract-name: dia-oracle-adapter
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/dia-oracle-adapter.clar
+            clarity-version: 3
+        - emulated-contract-publish:
             contract-name: oracle-trait
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/oracle-trait.clar
@@ -132,6 +137,16 @@ plan:
             contract-name: liquidation-engine-v2
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/liquidation-engine.clar
+            clarity-version: 3
+        - emulated-contract-publish:
+            contract-name: price-oracle-dia-btc
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/price-oracle-dia-btc.clar
+            clarity-version: 3
+        - emulated-contract-publish:
+            contract-name: price-oracle-dia-stx
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/price-oracle-dia-stx.clar
             clarity-version: 3
         - emulated-contract-publish:
             contract-name: price-oracle-sbtc-v3
@@ -173,6 +188,9 @@ plan:
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/sbtc-token-v3.clar
             clarity-version: 3
+      epoch: "3.1"
+    - id: 1
+      transactions:
         - emulated-contract-publish:
             contract-name: stability-pool
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
@@ -188,9 +206,6 @@ plan:
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/xreserve-adapter.clar
             clarity-version: 3
-      epoch: "3.1"
-    - id: 1
-      transactions:
         - emulated-contract-publish:
             contract-name: xreserve-adapter-v3
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM

--- a/deployments/dia-oracles.testnet-plan.yaml
+++ b/deployments/dia-oracles.testnet-plan.yaml
@@ -1,0 +1,62 @@
+---
+id: 0
+name: DIA Oracle Integration (testnet)
+network: testnet
+stacks-node: "https://api.testnet.hiro.so"
+bitcoin-node: "http://blockstack:blockstacksystem@bitcoind.testnet.stacks.co:18332"
+plan:
+  batches:
+    # Batch 0: Deploy traits and adapter first
+    - id: 0
+      transactions:
+        - contract-publish:
+            contract-name: oracle-trait
+            expected-sender: ST3DGG4B53XA12A6NQTXWK4346YPTC3B2B0ATA6HF
+            cost: 10000
+            path: contracts/oracle-trait.clar
+            anchor-block-only: true
+            clarity-version: 3
+        # Deploy the testnet adapter (forwards to real DIA) under the name "dia-oracle-adapter"
+        # so that price-oracle-dia-btc and price-oracle-dia-stx resolve .dia-oracle-adapter
+        - contract-publish:
+            contract-name: dia-oracle-adapter
+            expected-sender: ST3DGG4B53XA12A6NQTXWK4346YPTC3B2B0ATA6HF
+            cost: 12000
+            path: contracts/dia-oracle-adapter-testnet.clar
+            anchor-block-only: true
+            clarity-version: 3
+      epoch: "3.1"
+    # Batch 1: Deploy DIA wrapper oracles that depend on adapter
+    - id: 1
+      transactions:
+        - contract-publish:
+            contract-name: price-oracle-dia-btc
+            expected-sender: ST3DGG4B53XA12A6NQTXWK4346YPTC3B2B0ATA6HF
+            cost: 15000
+            path: contracts/price-oracle-dia-btc.clar
+            anchor-block-only: true
+            clarity-version: 3
+        - contract-publish:
+            contract-name: price-oracle-dia-stx
+            expected-sender: ST3DGG4B53XA12A6NQTXWK4346YPTC3B2B0ATA6HF
+            cost: 15000
+            path: contracts/price-oracle-dia-stx.clar
+            anchor-block-only: true
+            clarity-version: 3
+      epoch: "3.1"
+    # Batch 2: Register assets with DIA oracle IDs
+    # After deploying multi-asset-vault-engine-v3 (from default.testnet-plan),
+    # call register-asset-oracle with DIA IDs (u3 = DIA-BTC, u4 = DIA-STX)
+    # Example (uncomment and adjust asset principal):
+    # - id: 2
+    #   transactions:
+    #     - contract-call:
+    #         contract-id: ST3DGG4B53XA12A6NQTXWK4346YPTC3B2B0ATA6HF.multi-asset-vault-engine-v3
+    #         expected-sender: ST3DGG4B53XA12A6NQTXWK4346YPTC3B2B0ATA6HF
+    #         method: register-asset-oracle
+    #         parameters:
+    #           - "'ST3DGG4B53XA12A6NQTXWK4346YPTC3B2B0ATA6HF.sbtc-token-v3"
+    #           - "u3"
+    #         cost: 5000
+    #         anchor-block-only: true
+    #   epoch: "3.1"

--- a/docs/SSE_CONTEXT.md
+++ b/docs/SSE_CONTEXT.md
@@ -35,6 +35,6 @@ The repo still contains placeholders/TODOs for:
 - ~~custody transfers for pool assets~~ — **DONE**: `stability-pool-v3` now performs real SIP-010 token transfers with stablecoin-scoped balances
 - ~~liquidation reward accounting~~ — **DONE**: Creator-configurable reward percentage. Product-based deposit tracking for proportional loss. Reward-per-token pattern for collateral distribution.
 - ~~liquidation settlement logic~~ — **DONE**: Full orchestration in `liquidation-engine-v3`: health check → vault engine `liquidate-position` (seizes collateral, burns stablecoins) → stability pool `distribute-liquidation-reward`
-- production-grade oracle validation
+- ~~production-grade oracle validation~~ — **DONE**: DIA push-based oracle integration with staleness guard. `price-oracle-dia-btc` / `price-oracle-dia-stx` wrap DIA's `get-value` with configurable max-age check. Mock oracles (IDs 1/2) retained for simnet; DIA oracles (IDs 3/4) for testnet/mainnet.
 
 These are known prototype boundaries and should be documented when touched.

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -28,6 +28,9 @@ export const CONTRACTS = {
   STABILITY_POOL: "stability-pool-v3",
   PRICE_ORACLE_SBTC: "price-oracle-sbtc-v3",
   PRICE_ORACLE_STX: "price-oracle-stx-v3",
+  PRICE_ORACLE_DIA_BTC: "price-oracle-dia-btc",
+  PRICE_ORACLE_DIA_STX: "price-oracle-dia-stx",
+  DIA_ORACLE_ADAPTER: "dia-oracle-adapter",
   STABLECOIN_ENGINE_TOKEN_TRAIT: "stablecoin-engine-token-trait",
   BRIDGE_ADAPTER_TRAIT: "bridge-adapter-trait",
   BRIDGE_REGISTRY: "bridge-registry-v3",
@@ -42,6 +45,21 @@ export const APP_CONFIG = {
   name: "Stacks Stablecoin Engine",
   icon: "/logo.png",
 };
+
+// Oracle IDs matching contract constants in multi-asset-vault-engine-v3
+// Mock oracles (simnet/devnet): SBTC=1, STX=2
+// DIA oracles (testnet/mainnet): BTC=3, STX=4
+export const ORACLE_IDS = {
+  MOCK_SBTC: 1,
+  MOCK_STX: 2,
+  DIA_BTC: 3,
+  DIA_STX: 4,
+};
+
+// Use DIA oracles on testnet/mainnet, mock oracles on devnet
+const USE_DIA = NETWORK === "testnet" || NETWORK === "mainnet";
+export const ACTIVE_ORACLE_ID_BTC = USE_DIA ? ORACLE_IDS.DIA_BTC : ORACLE_IDS.MOCK_SBTC;
+export const ACTIVE_ORACLE_ID_STX = USE_DIA ? ORACLE_IDS.DIA_STX : ORACLE_IDS.MOCK_STX;
 
 // Default values (used when contracts aren't deployed or data can't be fetched)
 export const DEFAULTS = {

--- a/tests/dia-oracle.test.ts
+++ b/tests/dia-oracle.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+function getTestAccounts() {
+  const accounts = simnet.getAccounts();
+  const deployer = accounts.get("deployer");
+  const wallet1 = accounts.get("wallet_1");
+
+  if (!deployer || !wallet1) {
+    throw new Error("Missing default simnet accounts");
+  }
+
+  return { deployer, wallet1 };
+}
+
+/** Seed a DIA price for a given pair using the adapter's set-value. */
+function seedDiaPrice(deployer: string, pair: string, value: number) {
+  const result = simnet.callPublicFn(
+    "dia-oracle-adapter",
+    "set-value",
+    [Cl.stringAscii(pair), Cl.uint(value)],
+    deployer
+  );
+  expect(result.result).toBeOk(Cl.bool(true));
+}
+
+/** Seed a DIA price with an explicit timestamp. */
+function seedDiaPriceWithTimestamp(
+  deployer: string,
+  pair: string,
+  value: number,
+  timestamp: number
+) {
+  const result = simnet.callPublicFn(
+    "dia-oracle-adapter",
+    "set-value-with-timestamp",
+    [Cl.stringAscii(pair), Cl.uint(value), Cl.uint(timestamp)],
+    deployer
+  );
+  expect(result.result).toBeOk(Cl.bool(true));
+}
+
+// ============================================
+// DIA Oracle Adapter Tests
+// ============================================
+
+describe("dia-oracle-adapter", () => {
+  it("set-value stores and get-value retrieves BTC/USD", () => {
+    const { deployer } = getTestAccounts();
+    seedDiaPrice(deployer, "BTC/USD", 6700000000000);
+
+    const result = simnet.callReadOnlyFn(
+      "dia-oracle-adapter",
+      "get-value",
+      [Cl.stringAscii("BTC/USD")],
+      deployer
+    );
+    // Result is (ok {value: uint, timestamp: uint})
+    expect(result.result.type).toBe("ok");
+  });
+
+  it("set-value stores and get-value retrieves STX/USD", () => {
+    const { deployer } = getTestAccounts();
+    seedDiaPrice(deployer, "STX/USD", 21200000);
+
+    const result = simnet.callReadOnlyFn(
+      "dia-oracle-adapter",
+      "get-value",
+      [Cl.stringAscii("STX/USD")],
+      deployer
+    );
+    expect(result.result.type).toBe("ok");
+  });
+
+  it("get-value returns error for unknown pair", () => {
+    const { deployer } = getTestAccounts();
+
+    const result = simnet.callReadOnlyFn(
+      "dia-oracle-adapter",
+      "get-value",
+      [Cl.stringAscii("FOO/BAR")],
+      deployer
+    );
+    expect(result.result).toBeErr(Cl.uint(701)); // ERR_PAIR_NOT_FOUND
+  });
+
+  it("rejects set-value from non-owner", () => {
+    const { wallet1 } = getTestAccounts();
+
+    const result = simnet.callPublicFn(
+      "dia-oracle-adapter",
+      "set-value",
+      [Cl.stringAscii("BTC/USD"), Cl.uint(100)],
+      wallet1
+    );
+    expect(result.result).toBeErr(Cl.uint(700)); // ERR_UNAUTHORIZED
+  });
+
+  it("set-value-with-timestamp stores explicit timestamp", () => {
+    const { deployer } = getTestAccounts();
+    seedDiaPriceWithTimestamp(deployer, "BTC/USD", 6500000000000, 1000);
+
+    const result = simnet.callReadOnlyFn(
+      "dia-oracle-adapter",
+      "get-value",
+      [Cl.stringAscii("BTC/USD")],
+      deployer
+    );
+    expect(result.result.type).toBe("ok");
+  });
+});
+
+// ============================================
+// DIA BTC Oracle Wrapper Tests
+// ============================================
+
+describe("price-oracle-dia-btc", () => {
+  it("returns BTC price from DIA adapter when fresh", () => {
+    const { deployer } = getTestAccounts();
+    // Seed a fresh price (set-value uses current block time)
+    seedDiaPrice(deployer, "BTC/USD", 6700000000000);
+
+    const result = simnet.callReadOnlyFn(
+      "price-oracle-dia-btc",
+      "get-price",
+      [],
+      deployer
+    );
+    expect(result.result).toBeOk(Cl.uint(6700000000000));
+  });
+
+  it("rejects stale BTC price", () => {
+    const { deployer } = getTestAccounts();
+    // Seed a price with timestamp far in the past (0 = epoch start)
+    seedDiaPriceWithTimestamp(deployer, "BTC/USD", 6700000000000, 0);
+
+    const result = simnet.callReadOnlyFn(
+      "price-oracle-dia-btc",
+      "get-price",
+      [],
+      deployer
+    );
+    // ERR_STALE_PRICE = u601
+    expect(result.result).toBeErr(Cl.uint(601));
+  });
+
+  it("returns error when no price is set", () => {
+    const { deployer } = getTestAccounts();
+    // Don't seed any price — adapter returns ERR_PAIR_NOT_FOUND
+    // which the wrapper maps to ERR_NO_PRICE
+
+    // Note: if a previous test seeded BTC/USD, this test's simnet
+    // will be fresh (each describe/it gets a fresh simnet state)
+    const result = simnet.callReadOnlyFn(
+      "price-oracle-dia-btc",
+      "get-price",
+      [],
+      deployer
+    );
+    // ERR_NO_PRICE = u602
+    expect(result.result).toBeErr(Cl.uint(602));
+  });
+
+  it("owner can adjust max staleness", () => {
+    const { deployer } = getTestAccounts();
+
+    const setResult = simnet.callPublicFn(
+      "price-oracle-dia-btc",
+      "set-max-staleness",
+      [Cl.uint(7200)],
+      deployer
+    );
+    expect(setResult.result).toBeOk(Cl.bool(true));
+
+    const getResult = simnet.callReadOnlyFn(
+      "price-oracle-dia-btc",
+      "get-max-staleness",
+      [],
+      deployer
+    );
+    expect(getResult.result).toEqual(Cl.uint(7200));
+  });
+
+  it("rejects set-max-staleness from non-owner", () => {
+    const { wallet1 } = getTestAccounts();
+
+    const result = simnet.callPublicFn(
+      "price-oracle-dia-btc",
+      "set-max-staleness",
+      [Cl.uint(100)],
+      wallet1
+    );
+    expect(result.result).toBeErr(Cl.uint(600)); // ERR_UNAUTHORIZED
+  });
+});
+
+// ============================================
+// DIA STX Oracle Wrapper Tests
+// ============================================
+
+describe("price-oracle-dia-stx", () => {
+  it("returns STX price from DIA adapter when fresh", () => {
+    const { deployer } = getTestAccounts();
+    seedDiaPrice(deployer, "STX/USD", 21200000);
+
+    const result = simnet.callReadOnlyFn(
+      "price-oracle-dia-stx",
+      "get-price",
+      [],
+      deployer
+    );
+    expect(result.result).toBeOk(Cl.uint(21200000));
+  });
+
+  it("rejects stale STX price", () => {
+    const { deployer } = getTestAccounts();
+    seedDiaPriceWithTimestamp(deployer, "STX/USD", 21200000, 0);
+
+    const result = simnet.callReadOnlyFn(
+      "price-oracle-dia-stx",
+      "get-price",
+      [],
+      deployer
+    );
+    expect(result.result).toBeErr(Cl.uint(601)); // ERR_STALE_PRICE
+  });
+});
+
+// ============================================
+// Vault Engine DIA Oracle Integration Tests
+// ============================================
+
+describe("vault engine DIA oracle routing", () => {
+  it("register-asset-oracle accepts DIA-BTC oracle ID (u3)", () => {
+    const { deployer } = getTestAccounts();
+    const sbtcAsset = `${deployer}.sbtc-token-v3`;
+
+    const result = simnet.callPublicFn(
+      "multi-asset-vault-engine-v3",
+      "register-asset-oracle",
+      [Cl.principal(sbtcAsset), Cl.uint(3)],
+      deployer
+    );
+    expect(result.result).toBeOk(Cl.bool(true));
+  });
+
+  it("register-asset-oracle accepts DIA-STX oracle ID (u4)", () => {
+    const { deployer } = getTestAccounts();
+    const stxAsset = `${deployer}.stx-token-v3`;
+
+    const result = simnet.callPublicFn(
+      "multi-asset-vault-engine-v3",
+      "register-asset-oracle",
+      [Cl.principal(stxAsset), Cl.uint(4)],
+      deployer
+    );
+    expect(result.result).toBeOk(Cl.bool(true));
+  });
+
+  it("register-asset-oracle rejects unknown oracle ID (u5)", () => {
+    const { deployer } = getTestAccounts();
+    const sbtcAsset = `${deployer}.sbtc-token-v3`;
+
+    const result = simnet.callPublicFn(
+      "multi-asset-vault-engine-v3",
+      "register-asset-oracle",
+      [Cl.principal(sbtcAsset), Cl.uint(5)],
+      deployer
+    );
+    expect(result.result).toBeErr(Cl.uint(214)); // ERR_UNKNOWN_ORACLE
+  });
+
+  it("vault engine reads BTC price via DIA oracle ID", () => {
+    const { deployer, wallet1 } = getTestAccounts();
+    const sbtcAsset = `${deployer}.sbtc-token-v3`;
+    const oraclePrincipal = `${deployer}.price-oracle-sbtc-v3`;
+    const tokenPrincipal = `${deployer}.stablecoin-token-v3`;
+
+    // Seed DIA BTC price
+    seedDiaPrice(deployer, "BTC/USD", 6700000000000);
+
+    // Register sBTC with DIA-BTC oracle (ID 3)
+    simnet.callPublicFn(
+      "multi-asset-vault-engine-v3",
+      "register-asset-oracle",
+      [Cl.principal(sbtcAsset), Cl.uint(3)],
+      deployer
+    );
+
+    // Setup: add global collateral, factory, etc.
+    simnet.callPublicFn("stablecoin-factory-v3", "set-registration-fee", [Cl.uint(0)], deployer);
+    simnet.callPublicFn(
+      "stablecoin-factory-v3",
+      "register-stablecoin",
+      [Cl.stringAscii("DIA Dollar"), Cl.stringAscii("DUSD")],
+      wallet1
+    );
+    simnet.callPublicFn(
+      "stablecoin-factory-v3",
+      "set-token-contract",
+      [Cl.uint(0), Cl.principal(tokenPrincipal)],
+      wallet1
+    );
+    simnet.callPublicFn(
+      "collateral-registry-v3",
+      "add-collateral-type",
+      [
+        Cl.principal(sbtcAsset),
+        Cl.uint(150), Cl.uint(120), Cl.uint(10), Cl.uint(200),
+        Cl.uint(10000000), Cl.uint(100),
+        Cl.principal(oraclePrincipal),
+      ],
+      deployer
+    );
+    simnet.callPublicFn(
+      "collateral-registry-v3",
+      "configure-collateral-for-stablecoin",
+      [
+        Cl.uint(0), Cl.principal(sbtcAsset),
+        Cl.uint(150), Cl.uint(120), Cl.uint(10), Cl.uint(200),
+        Cl.uint(10000000), Cl.uint(100),
+      ],
+      wallet1
+    );
+    simnet.callPublicFn(
+      "stablecoin-token-v3",
+      "set-vault-engine",
+      [Cl.principal(`${deployer}.multi-asset-vault-engine-v3`)],
+      deployer
+    );
+
+    // Faucet sBTC + open vault + deposit
+    simnet.callPublicFn("sbtc-token-v3", "faucet-mint", [Cl.uint(10000), Cl.principal(wallet1)], wallet1);
+    simnet.callPublicFn("multi-asset-vault-engine-v3", "open-vault-for-stablecoin", [Cl.uint(0)], wallet1);
+    simnet.callPublicFn(
+      "multi-asset-vault-engine-v3",
+      "deposit-collateral-for-stablecoin",
+      [Cl.uint(0), Cl.principal(sbtcAsset), Cl.principal(sbtcAsset), Cl.uint(10000)],
+      wallet1
+    );
+
+    // Mint stablecoins — this triggers the vault engine to read the DIA oracle price
+    const mintResult = simnet.callPublicFn(
+      "multi-asset-vault-engine-v3",
+      "mint-against-asset-for-stablecoin",
+      [Cl.uint(0), Cl.principal(sbtcAsset), Cl.principal(tokenPrincipal), Cl.uint(2000)],
+      wallet1
+    );
+    expect(mintResult.result).toBeOk(Cl.uint(2000));
+
+    // Verify health factor is computed using DIA price
+    const healthResult = simnet.callReadOnlyFn(
+      "multi-asset-vault-engine-v3",
+      "get-position-health-factor-for-stablecoin",
+      [Cl.principal(wallet1), Cl.uint(0), Cl.principal(sbtcAsset)],
+      deployer
+    );
+    // Health factor should be > 0 (vault is healthy)
+    const healthValue = (healthResult.result as any).value;
+    expect(Number(healthValue)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Add DIA oracle adapter and wrapper contracts for BTC/USD and STX/USD price feeds with configurable staleness guards. Implement dia-oracle-adapter as owner-settable mock for simnet/devnet and forwarding adapter for testnet/mainnet. Add price-oracle-dia-btc and price-oracle-dia-stx contracts with 1-hour default staleness threshold and owner-controlled tuning. Extend multi-asset-vault-engine-v3 with ORACLE-DIA-BTC (u3) and ORACLE-DIA-