### PR TITLE
feat: add SSE Finance trait package with pegged USD oracle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,26 @@ SSE deals with multiple tokens that have different decimal precisions (e.g. sBTC
 
 **Steps 3 and 4 can run in parallel** (frontend update and docs update are independent). But NEVER skip them. A deployment without frontend and docs updates is an incomplete deployment.
 
+## Testing Requirements
+
+- **Every PR ships tests.** All new code must be covered: at minimum every
+  happy-path scenario, plus some failure scenarios. Add unit tests **and**
+  integration tests at the end of each PR — they are part of the PR, never
+  deferred to a later task.
+- **Contracts:** vitest + clarinet-sdk (simnet) under `tests/`. Run a single
+  file with `./node_modules/.bin/vitest run tests/<file>.test.ts`. Do **not** use
+  `npx vitest` — it fetches a wrong global version; root deps come from
+  `npm install` at the repo root.
+- **Cover every public and read-only function and every branch.** If a branch is
+  unreachable by construction (e.g. a monotonic-time underflow guard), remove the
+  dead guard with a comment explaining the invariant rather than leaving it
+  untestable.
+- **Measuring coverage:** `vitest run <file> -- --coverage` writes `lcov.info`.
+  With `initBeforeEach`, lcov emits one `SF` block per test init (the first is an
+  unexecuted baseline), so aggregate `DA`/`BRDA` across all blocks for a file
+  before judging coverage.
+- Pure trait files (`define-trait` only) have no executable lines — nothing to test.
+
 ## Validation Checklist
 
 After changes:

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -25,6 +25,25 @@ epoch = "3.1"
 path = "contracts/bridge-adapter-trait.clar"
 epoch = "3.1"
 
+# ── SSE Finance (fresh, self-contained package) ───────────────────────────────
+# SSE Finance is deployed clean with its own trait set so nothing points at an
+# externally-deployed trait contract. Borrow tokens + collateral are plain
+# SIP-010 (no mint/burn) -- SSE Finance never mints.
+
+[contracts.sse-finance-oracle-trait]
+path = "contracts/sse-finance-oracle-trait.clar"
+epoch = "3.1"
+
+[contracts.sse-finance-sip-010-trait]
+path = "contracts/sse-finance-sip-010-trait.clar"
+epoch = "3.1"
+
+# Reusable governance-pegged ~$1 oracle shared by every USD stablecoin market.
+[contracts.price-oracle-pegged-usd-v1]
+path = "contracts/price-oracle-pegged-usd-v1.clar"
+epoch = "3.1"
+depends_on = ["sse-finance-oracle-trait"]
+
 # ── Governance ────────────────────────────────────────────────────────────────
 
 [contracts.sse-governance-v1]

--- a/contracts/price-oracle-pegged-usd-v1.clar
+++ b/contracts/price-oracle-pegged-usd-v1.clar
@@ -1,0 +1,183 @@
+;; price-oracle-pegged-usd-v1.clar
+;;
+;; Reusable governance-pegged USD oracle for SSE Finance.
+;;
+;; One deployed instance serves EVERY USD stablecoin market (USDC, USDA, USDCX,
+;; ...): they all share a single governance-settable peg of ~$1. There is no
+;; per-token state, so no per-token oracle is required. A market that needs a
+;; live feed instead simply points at a different oracle principal (any contract
+;; implementing sse-finance-oracle-trait) -- no redeploy of this contract or of
+;; the consumer.
+;;
+;; Guards:
+;;   - Deviation guard (always on): set-peg-price rejects any peg outside a
+;;     governance-set band around $1, so a fat-fingered or malicious peg can
+;;     never move the price arbitrarily far from the dollar.
+;;   - Staleness guard (opt-in): if max-staleness > 0, get-price fails once the
+;;     peg has not been re-attested within that many seconds. Default is u0
+;;     (disabled) because the common case is a constant $1 peg that needs no
+;;     refresh; enabling it forces periodic governance re-attestation.
+;;
+;; The oracle-trait get-price returns only the uint price (kept compatible with
+;; all consumers). The freshness / last-update signal is exposed separately via
+;; get-last-update and get-price-info.
+
+(impl-trait .sse-finance-oracle-trait.sse-finance-oracle-trait)
+
+(define-constant CONTRACT-OWNER tx-sender)
+
+;; 8-decimal price scale, matching the SSE vault engine. $1.00 = u100000000.
+(define-constant PRICE-SCALE u100000000)
+(define-constant PRICE-USD-1 PRICE-SCALE)
+(define-constant BPS-DENOM u10000)
+
+;; ============================================
+;; Error Constants
+;; ============================================
+(define-constant ERR_UNAUTHORIZED u700)
+(define-constant ERR_BOOTSTRAP_LOCKED u701)
+(define-constant ERR_DEVIATION_TOO_LARGE u702)
+(define-constant ERR_STALE_PRICE u703)
+(define-constant ERR_INVALID_PARAM u704)
+
+;; ============================================
+;; Governance (mirrors collateral-registry-v6)
+;; ============================================
+(define-data-var governance principal CONTRACT-OWNER)
+(define-data-var bootstrap-locked bool false)
+
+(define-read-only (get-governance) (var-get governance))
+(define-read-only (is-bootstrap-locked) (var-get bootstrap-locked))
+
+(define-public (bootstrap-set-governance (new-gov principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (asserts! (not (var-get bootstrap-locked)) (err ERR_BOOTSTRAP_LOCKED))
+    (var-set governance new-gov)
+    (ok true)
+  )
+)
+
+(define-public (lock-bootstrap)
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (var-set bootstrap-locked true)
+    (ok true)
+  )
+)
+
+(define-private (is-governance-caller)
+  (or
+    (is-eq contract-caller (var-get governance))
+    (and (not (var-get bootstrap-locked)) (is-eq tx-sender CONTRACT-OWNER))
+  )
+)
+
+;; ============================================
+;; Peg state
+;; ============================================
+;; Current peg price (8-decimal). Starts at exactly $1.00.
+(define-data-var peg-price uint PRICE-USD-1)
+;; stacks-block time (seconds) at the last set-peg-price call. u0 = never set.
+(define-data-var last-update uint u0)
+;; Max allowed deviation of the peg from $1, in bps. Default 200 = 2%.
+(define-data-var max-deviation-bps uint u200)
+;; Staleness window in seconds; u0 disables the staleness check (default).
+(define-data-var max-staleness uint u0)
+
+;; Best-effort current time from the previous Stacks block. u0 if unavailable.
+(define-read-only (current-time)
+  (default-to u0 (get-stacks-block-info? time (- stacks-block-height u1)))
+)
+
+;; True iff price is within max-deviation-bps of $1. bps is capped at BPS-DENOM
+;; on set, so band <= PRICE-USD-1 and the lower bound never underflows.
+(define-private (within-band (price uint))
+  (let (
+      (band (/ (* PRICE-USD-1 (var-get max-deviation-bps)) BPS-DENOM))
+    )
+    (and (>= price (- PRICE-USD-1 band)) (<= price (+ PRICE-USD-1 band)))
+  )
+)
+
+;; ============================================
+;; Governance-gated setters
+;; ============================================
+
+;; Set the peg, rejecting anything outside the deviation band around $1.
+(define-public (set-peg-price (new-price uint))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (asserts! (within-band new-price) (err ERR_DEVIATION_TOO_LARGE))
+    (var-set peg-price new-price)
+    (var-set last-update (current-time))
+    (ok true)
+  )
+)
+
+(define-public (set-max-deviation-bps (bps uint))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (asserts! (<= bps BPS-DENOM) (err ERR_INVALID_PARAM))
+    (var-set max-deviation-bps bps)
+    (ok true)
+  )
+)
+
+(define-public (set-max-staleness (secs uint))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (var-set max-staleness secs)
+    (ok true)
+  )
+)
+
+;; ============================================
+;; Oracle trait implementation
+;; ============================================
+
+;; Returns the peg price. If a staleness window is configured, fails when the
+;; peg has not been re-attested within it.
+(define-read-only (get-price)
+  (let ((staleness (var-get max-staleness)))
+    (if (is-eq staleness u0)
+      (ok (var-get peg-price))
+      (let (
+          (now (current-time))
+          (lu (var-get last-update))
+          (age (if (>= now lu) (- now lu) u0))
+        )
+        (asserts! (<= age staleness) (err ERR_STALE_PRICE))
+        (ok (var-get peg-price))
+      )
+    )
+  )
+)
+
+;; ============================================
+;; Freshness / introspection read-onlys
+;; ============================================
+(define-read-only (get-peg-price) (var-get peg-price))
+(define-read-only (get-last-update) (var-get last-update))
+(define-read-only (get-max-staleness) (var-get max-staleness))
+(define-read-only (get-max-deviation-bps) (var-get max-deviation-bps))
+
+;; Full price + freshness snapshot for consumers/monitors.
+(define-read-only (get-price-info)
+  (let (
+      (now (current-time))
+      (lu (var-get last-update))
+      (staleness (var-get max-staleness))
+      (age (if (>= now lu) (- now lu) u0))
+    )
+    {
+      price: (var-get peg-price),
+      last-update: lu,
+      now: now,
+      age: age,
+      max-staleness: staleness,
+      max-deviation-bps: (var-get max-deviation-bps),
+      fresh: (or (is-eq staleness u0) (<= age staleness))
+    }
+  )
+)

--- a/contracts/price-oracle-pegged-usd-v1.clar
+++ b/contracts/price-oracle-pegged-usd-v1.clar
@@ -144,8 +144,9 @@
       (ok (var-get peg-price))
       (let (
           (now (current-time))
-          (lu (var-get last-update))
-          (age (if (>= now lu) (- now lu) u0))
+          ;; last-update is u0 or a past block's time, and now = time(height-1)
+          ;; is monotonic, so now >= last-update always -- no underflow here.
+          (age (- now (var-get last-update)))
         )
         (asserts! (<= age staleness) (err ERR_STALE_PRICE))
         (ok (var-get peg-price))
@@ -168,7 +169,8 @@
       (now (current-time))
       (lu (var-get last-update))
       (staleness (var-get max-staleness))
-      (age (if (>= now lu) (- now lu) u0))
+      ;; now >= lu always (see get-price), so no underflow.
+      (age (- now lu))
     )
     {
       price: (var-get peg-price),

--- a/contracts/sse-finance-oracle-trait.clar
+++ b/contracts/sse-finance-oracle-trait.clar
@@ -1,0 +1,17 @@
+;; sse-finance-oracle-trait.clar
+;;
+;; Fresh, in-package copy of the price-oracle trait for the SSE Finance
+;; deployment. Identical surface to the existing oracle-trait.clar, but
+;; redeclared here so every SSE Finance contract `use-trait`s its OWN trait set
+;; and nothing points at an externally-deployed trait contract.
+;;
+;; get-price returns a USD price at the 8-decimal PRICE-SCALE used throughout
+;; SSE (u100000000 = $1.00). Any contract implementing this trait can serve as a
+;; market's oracle, so a market can be re-pointed at a different oracle principal
+;; without redeploying the consumer.
+
+(define-trait sse-finance-oracle-trait
+  (
+    (get-price () (response uint uint))
+  )
+)

--- a/contracts/sse-finance-sip-010-trait.clar
+++ b/contracts/sse-finance-sip-010-trait.clar
@@ -1,0 +1,26 @@
+;; sse-finance-sip-010-trait.clar
+;;
+;; Fresh, in-package copy of the standard SIP-010 fungible-token trait for the
+;; SSE Finance deployment. Redeclared here so SSE Finance points only at its own
+;; trait set, never an externally-deployed trait contract.
+;;
+;; This is the canonical SIP-010 surface (including the optional memo on
+;; transfer) so that real external stablecoins onboarded as borrow tokens, and
+;; their collateral assets, satisfy it as plain SIP-010 references.
+;;
+;; PLAIN SIP-010 ONLY -- no mint/burn capability is part of this trait. SSE
+;; Finance never mints: borrow tokens are moved from the pool's existing balance,
+;; not minted, and collateral is custodied, not issued.
+
+(define-trait sse-finance-sip-010-trait
+  (
+    ;; Transfer amount of token from sender to recipient, with optional memo.
+    (transfer (uint principal principal (optional (buff 34))) (response bool uint))
+    (get-name () (response (string-ascii 32) uint))
+    (get-symbol () (response (string-ascii 32) uint))
+    (get-decimals () (response uint uint))
+    (get-balance (principal) (response uint uint))
+    (get-total-supply () (response uint uint))
+    (get-token-uri () (response (optional (string-utf8 256)) uint))
+  )
+)

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -58,6 +58,7 @@ genesis:
     - pox-4
     - signers
     - signers-voting
+    - costs-4
 plan:
   batches:
     - id: 0
@@ -67,7 +68,7 @@ plan:
             emulated-sender: SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE
             path: "./.cache/requirements/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.clar"
             clarity-version: 1
-      epoch: "2.0"
+      epoch: "2.1"
     - id: 1
       transactions:
         - emulated-contract-publish:

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -58,7 +58,6 @@ genesis:
     - pox-4
     - signers
     - signers-voting
-    - costs-4
 plan:
   batches:
     - id: 0
@@ -68,7 +67,7 @@ plan:
             emulated-sender: SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE
             path: "./.cache/requirements/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.clar"
             clarity-version: 1
-      epoch: "2.1"
+      epoch: "2.0"
     - id: 1
       transactions:
         - emulated-contract-publish:
@@ -162,6 +161,16 @@ plan:
             path: contracts/price-oracle-egpb-v1.clar
             clarity-version: 3
         - emulated-contract-publish:
+            contract-name: sse-finance-oracle-trait
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/sse-finance-oracle-trait.clar
+            clarity-version: 3
+        - emulated-contract-publish:
+            contract-name: price-oracle-pegged-usd-v1
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/price-oracle-pegged-usd-v1.clar
+            clarity-version: 3
+        - emulated-contract-publish:
             contract-name: price-oracle-vgld-v1
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/price-oracle-vgld-v1.clar
@@ -170,6 +179,11 @@ plan:
             contract-name: sbtc-token-v4
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/sbtc-token-v4.clar
+            clarity-version: 3
+        - emulated-contract-publish:
+            contract-name: sse-finance-sip-010-trait
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/sse-finance-sip-010-trait.clar
             clarity-version: 3
         - emulated-contract-publish:
             contract-name: sse-governance-v1
@@ -181,6 +195,9 @@ plan:
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/xreserve-adapter-v5.clar
             clarity-version: 3
+      epoch: "3.1"
+    - id: 2
+      transactions:
         - emulated-contract-publish:
             contract-name: sse-timelock-v1
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM

--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -1,0 +1,29 @@
+# Fixes ChunkLoadError / white-screen in production.
+#
+# Cause: Netlify Edge was serving a stale, per-accept-encoding (brotli) HTML
+# variant of pages. That stale document referenced hashed JS chunks that later
+# deploys had deleted (chunk hashes rotate every build, and /_next/static is
+# served "immutable"). The browser loaded the old HTML, requested the dead
+# chunk, got a 404, and React crashed to a blank page.
+#
+# Fix: never let the CDN durably cache HTML documents / RSC payloads, so they
+# always reflect the current deploy and can never name a removed chunk. The
+# content-addressed build assets under /_next/static are safe to cache forever.
+#
+# Note: Netlify-CDN-Cache-Control controls only Netlify's edge; browser caching
+# is still governed by the Cache-Control headers the Next runtime emits.
+# More-specific paths take precedence, so the immutable rule below wins for
+# /_next/static even though the /* rule also matches it.
+
+# Content-addressed build assets: safe to cache forever at the edge.
+[[headers]]
+  for = "/_next/static/*"
+  [headers.values]
+    Netlify-CDN-Cache-Control = "public, max-age=31536000, immutable"
+
+# HTML documents and RSC payloads: never durably edge-cache, or a stale doc can
+# point at a chunk hash that a newer deploy removed.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Netlify-CDN-Cache-Control = "no-store"

--- a/tests/price-oracle-pegged-usd.test.ts
+++ b/tests/price-oracle-pegged-usd.test.ts
@@ -1,0 +1,242 @@
+// Full-coverage tests for price-oracle-pegged-usd-v1: the reusable
+// governance-pegged ~$1 USD oracle for SSE Finance.
+//
+// Exercises every public + read-only function and every branch:
+//   - governance handoff (bootstrap-set-governance / lock-bootstrap) and all
+//     three is-governance-caller branches (governance caller, pre-lock owner,
+//     neither),
+//   - set-peg-price deviation guard at/inside/outside both band edges,
+//     including the bps=0 (exact-$1 only) and bps=10000 (0..$2) extremes,
+//     and the bps cap rejection,
+//   - set-max-staleness and the get-price staleness guard (disabled / fresh /
+//     stale) plus get-price-info freshness reporting.
+
+import { describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+const ORACLE = "price-oracle-pegged-usd-v1";
+
+const USD_1 = 100_000_000; // $1.00 at 8-decimal PRICE-SCALE
+
+// Error codes (must match the contract).
+const ERR_UNAUTHORIZED = 700;
+const ERR_BOOTSTRAP_LOCKED = 701;
+const ERR_DEVIATION_TOO_LARGE = 702;
+const ERR_STALE_PRICE = 703;
+const ERR_INVALID_PARAM = 704;
+
+function accounts() {
+  const a = simnet.getAccounts();
+  const deployer = a.get("deployer")!;
+  const wallet1 = a.get("wallet_1")!;
+  const wallet2 = a.get("wallet_2")!;
+  return { deployer, wallet1, wallet2 };
+}
+
+const setPeg = (price: number, caller: string) =>
+  simnet.callPublicFn(ORACLE, "set-peg-price", [Cl.uint(price)], caller);
+const setDeviation = (bps: number, caller: string) =>
+  simnet.callPublicFn(ORACLE, "set-max-deviation-bps", [Cl.uint(bps)], caller);
+const setStaleness = (secs: number, caller: string) =>
+  simnet.callPublicFn(ORACLE, "set-max-staleness", [Cl.uint(secs)], caller);
+const read = (fn: string, caller: string) =>
+  simnet.callReadOnlyFn(ORACLE, fn, [], caller);
+
+// Pull a field CV out of the get-price-info tuple.
+function infoFieldCV(caller: string, field: string): any {
+  const info = read("get-price-info", caller).result as any;
+  return info.value[field];
+}
+const infoUint = (caller: string, field: string): bigint =>
+  infoFieldCV(caller, field).value as bigint;
+// Booleans in @stacks/transactions v7 are { type: "true" | "false" } (no value).
+const infoBool = (caller: string, field: string): boolean =>
+  infoFieldCV(caller, field).type === "true";
+
+describe("price-oracle-pegged-usd-v1: initial state", () => {
+  it("defaults: peg=$1, last-update=0, staleness off, deviation 2%, governance=deployer, unlocked", () => {
+    const { deployer } = accounts();
+    expect(read("get-peg-price", deployer).result).toBeUint(USD_1);
+    expect(read("get-last-update", deployer).result).toBeUint(0);
+    expect(read("get-max-staleness", deployer).result).toBeUint(0);
+    expect(read("get-max-deviation-bps", deployer).result).toBeUint(200);
+    expect(read("get-governance", deployer).result).toBePrincipal(deployer);
+    expect(read("is-bootstrap-locked", deployer).result).toBeBool(false);
+  });
+
+  it("get-price returns the $1 peg when staleness is disabled", () => {
+    const { wallet1 } = accounts();
+    expect(read("get-price", wallet1).result).toBeOk(Cl.uint(USD_1));
+  });
+
+  it("get-price-info reports fresh=true with staleness disabled", () => {
+    const { wallet1 } = accounts();
+    expect(infoUint(wallet1, "price")).toBe(BigInt(USD_1));
+    expect(infoUint(wallet1, "max-staleness")).toBe(0n);
+    expect(infoBool(wallet1, "fresh")).toBe(true);
+  });
+});
+
+describe("price-oracle-pegged-usd-v1: set-peg-price deviation guard (default 2% band)", () => {
+  // band = USD_1 * 200 / 10000 = 2_000_000 -> [98_000_000, 102_000_000]
+  it("accepts the exact peg ($1)", () => {
+    const { deployer } = accounts();
+    expect(setPeg(USD_1, deployer).result).toBeOk(Cl.bool(true));
+    expect(read("get-peg-price", deployer).result).toBeUint(USD_1);
+    // last-update is stamped from block time (> 0 after the call)
+    expect(Number((read("get-last-update", deployer).result as any).value as bigint)).toBeGreaterThan(0);
+  });
+
+  it("accepts the upper band edge (102_000_000)", () => {
+    const { deployer } = accounts();
+    expect(setPeg(102_000_000, deployer).result).toBeOk(Cl.bool(true));
+    expect(read("get-peg-price", deployer).result).toBeUint(102_000_000);
+  });
+
+  it("accepts the lower band edge (98_000_000)", () => {
+    const { deployer } = accounts();
+    expect(setPeg(98_000_000, deployer).result).toBeOk(Cl.bool(true));
+    expect(read("get-peg-price", deployer).result).toBeUint(98_000_000);
+  });
+
+  it("rejects one tick above the band", () => {
+    const { deployer } = accounts();
+    expect(setPeg(102_000_001, deployer).result).toBeErr(Cl.uint(ERR_DEVIATION_TOO_LARGE));
+  });
+
+  it("rejects one tick below the band", () => {
+    const { deployer } = accounts();
+    expect(setPeg(97_999_999, deployer).result).toBeErr(Cl.uint(ERR_DEVIATION_TOO_LARGE));
+  });
+});
+
+describe("price-oracle-pegged-usd-v1: set-max-deviation-bps", () => {
+  it("rejects bps above the 10000 cap", () => {
+    const { deployer } = accounts();
+    expect(setDeviation(10001, deployer).result).toBeErr(Cl.uint(ERR_INVALID_PARAM));
+  });
+
+  it("bps=10000 widens the band to [0, $2]", () => {
+    const { deployer } = accounts();
+    expect(setDeviation(10000, deployer).result).toBeOk(Cl.bool(true));
+    expect(read("get-max-deviation-bps", deployer).result).toBeUint(10000);
+    expect(setPeg(1, deployer).result).toBeOk(Cl.bool(true)); // lower edge (0..)
+    expect(setPeg(200_000_000, deployer).result).toBeOk(Cl.bool(true)); // upper edge $2
+    expect(setPeg(200_000_001, deployer).result).toBeErr(Cl.uint(ERR_DEVIATION_TOO_LARGE));
+  });
+
+  it("bps=0 pins the peg to exactly $1", () => {
+    const { deployer } = accounts();
+    expect(setDeviation(0, deployer).result).toBeOk(Cl.bool(true));
+    expect(setPeg(USD_1, deployer).result).toBeOk(Cl.bool(true));
+    expect(setPeg(USD_1 + 1, deployer).result).toBeErr(Cl.uint(ERR_DEVIATION_TOO_LARGE));
+    expect(setPeg(USD_1 - 1, deployer).result).toBeErr(Cl.uint(ERR_DEVIATION_TOO_LARGE));
+  });
+});
+
+describe("price-oracle-pegged-usd-v1: staleness guard", () => {
+  it("get-price stays ok when staleness window is large enough", () => {
+    const { deployer, wallet1 } = accounts();
+    expect(setPeg(USD_1, deployer).result).toBeOk(Cl.bool(true));
+    expect(setStaleness(1_000_000_000_000, deployer).result).toBeOk(Cl.bool(true));
+    expect(read("get-price", wallet1).result).toBeOk(Cl.uint(USD_1));
+    expect(infoBool(wallet1, "fresh")).toBe(true);
+  });
+
+  it("get-price fails ERR_STALE_PRICE once the window elapses", () => {
+    const { deployer, wallet1 } = accounts();
+    expect(setPeg(USD_1, deployer).result).toBeOk(Cl.bool(true));
+    // Advance chain time well past a 1-second window.
+    simnet.mineEmptyBlocks(20);
+    expect(setStaleness(1, deployer).result).toBeOk(Cl.bool(true));
+
+    const age = Number(infoUint(wallet1, "age"));
+    expect(age).toBeGreaterThan(1); // sanity: time actually advanced
+
+    expect(read("get-price", wallet1).result).toBeErr(Cl.uint(ERR_STALE_PRICE));
+    expect(infoBool(wallet1, "fresh")).toBe(false);
+  });
+});
+
+describe("price-oracle-pegged-usd-v1: governance gating", () => {
+  it("non-owner cannot set peg / deviation / staleness", () => {
+    const { wallet2 } = accounts();
+    expect(setPeg(USD_1, wallet2).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(setDeviation(100, wallet2).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(setStaleness(10, wallet2).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+  });
+
+  it("bootstrap-set-governance rejects non-owner", () => {
+    const { wallet1, wallet2 } = accounts();
+    expect(
+      simnet.callPublicFn(ORACLE, "bootstrap-set-governance", [Cl.principal(wallet1)], wallet2)
+        .result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+  });
+
+  it("lock-bootstrap rejects non-owner", () => {
+    const { wallet2 } = accounts();
+    expect(simnet.callPublicFn(ORACLE, "lock-bootstrap", [], wallet2).result).toBeErr(
+      Cl.uint(ERR_UNAUTHORIZED)
+    );
+  });
+
+  it("after handoff: new governance can set peg (contract-caller branch)", () => {
+    const { deployer, wallet1 } = accounts();
+    expect(
+      simnet.callPublicFn(ORACLE, "bootstrap-set-governance", [Cl.principal(wallet1)], deployer)
+        .result
+    ).toBeOk(Cl.bool(true));
+    expect(read("get-governance", deployer).result).toBePrincipal(wallet1);
+    // wallet1 is now governance -> contract-caller == governance branch
+    expect(setPeg(101_000_000, wallet1).result).toBeOk(Cl.bool(true));
+  });
+
+  it("pre-lock owner can still set peg even after handoff (owner-fallback branch)", () => {
+    const { deployer, wallet1 } = accounts();
+    simnet.callPublicFn(ORACLE, "bootstrap-set-governance", [Cl.principal(wallet1)], deployer);
+    // governance is wallet1, but bootstrap is unlocked and deployer is owner
+    expect(setPeg(99_500_000, deployer).result).toBeOk(Cl.bool(true));
+  });
+
+  it("after lock + handoff, the owner loses access (both branches false)", () => {
+    const { deployer, wallet1, wallet2 } = accounts();
+    simnet.callPublicFn(ORACLE, "bootstrap-set-governance", [Cl.principal(wallet1)], deployer);
+    expect(simnet.callPublicFn(ORACLE, "lock-bootstrap", [], deployer).result).toBeOk(
+      Cl.bool(true)
+    );
+    expect(read("is-bootstrap-locked", deployer).result).toBeBool(true);
+
+    // owner no longer governance and bootstrap locked -> rejected
+    expect(setPeg(USD_1, deployer).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    // random principal -> rejected
+    expect(setPeg(USD_1, wallet2).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    // governance (wallet1) still works
+    expect(setPeg(USD_1, wallet1).result).toBeOk(Cl.bool(true));
+  });
+
+  it("bootstrap-set-governance rejects once bootstrap is locked", () => {
+    const { deployer, wallet2 } = accounts();
+    expect(simnet.callPublicFn(ORACLE, "lock-bootstrap", [], deployer).result).toBeOk(
+      Cl.bool(true)
+    );
+    expect(
+      simnet.callPublicFn(ORACLE, "bootstrap-set-governance", [Cl.principal(wallet2)], deployer)
+        .result
+    ).toBeErr(Cl.uint(ERR_BOOTSTRAP_LOCKED));
+  });
+});
+
+describe("price-oracle-pegged-usd-v1: introspection getters", () => {
+  it("getters reflect updated values", () => {
+    const { deployer } = accounts();
+    setDeviation(500, deployer);
+    setStaleness(3600, deployer);
+    setPeg(101_000_000, deployer);
+
+    expect(read("get-max-deviation-bps", deployer).result).toBeUint(500);
+    expect(read("get-max-staleness", deployer).result).toBeUint(3600);
+    expect(read("get-peg-price", deployer).result).toBeUint(101_000_000);
+    expect(Number((read("get-last-update", deployer).result as any).value as bigint)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Add sse-finance-oracle-trait and sse-finance-sip-010-trait as fresh in-package trait copies so SSE Finance deployment points only at its own trait set instead of externally-deployed trait contracts. Add price-oracle-pegged-usd-v1 reusable governance-pegged ~$1 oracle shared by all USD stablecoin markets (USDC/USDA/USDCX) with deviation guard (default 2% band around $1) and optional staleness guard (disabled by default).