### PR TITLE
feat: add sse-finance-market-registry-v1 with enumerable markets, separate fee-config, and treasury accrual 

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -44,6 +44,13 @@ path = "contracts/price-oracle-pegged-usd-v1.clar"
 epoch = "3.1"
 depends_on = ["sse-finance-oracle-trait"]
 
+# Market registry: the standard import path by which any SIP-010 stablecoin
+# becomes borrowable. Markets + a separate capped fee-config + treasury accrual.
+[contracts.sse-finance-market-registry-v1]
+path = "contracts/sse-finance-market-registry-v1.clar"
+epoch = "3.1"
+depends_on = []
+
 # ── Governance ────────────────────────────────────────────────────────────────
 
 [contracts.sse-governance-v1]

--- a/contracts/sse-finance-market-registry-v1.clar
+++ b/contracts/sse-finance-market-registry-v1.clar
@@ -1,0 +1,402 @@
+;; sse-finance-market-registry-v1.clar
+;;
+;; The market registry for SSE Finance: the single, standard mechanism by which
+;; any plain SIP-010 stablecoin becomes borrowable. A "market" is one borrowable
+;; stablecoin together with its oracle, borrow cap, and enabled/paused flags. A
+;; *separate* fee-config map holds the economic fee dials, independently
+;; updatable from the market wiring.
+;;
+;; Structure mirrors collateral-registry-v6:
+;;   - enumerable market list (sequential market-id == enumeration index),
+;;   - per-key config (markets) + a separate per-key fee-config,
+;;   - a governance gate (bootstrap owner -> timelock, then lock-bootstrap),
+;;   - an authorized-caller map so the vault/pool can record protocol fees.
+;;
+;; INTEREST-FREE (Liquity-style): there is deliberately NO reserve-factor /
+;; interest-rate / index field anywhere. Protocol revenue is only the one-time
+;; borrow fee + a cut of the liquidation penalty, accrued into treasury-accrued
+;; and later swept to the governance-set treasury.
+
+;; The borrow-token and oracle are stored as plain principals (as
+;; collateral-registry-v6 stores its oracle). Trait typing (use-trait) happens at
+;; the vault/pool call sites that actually invoke transfer / get-price; the
+;; registry only records and validates the wiring, so it imports no traits.
+
+(define-constant CONTRACT-OWNER tx-sender)
+
+;; ============================================
+;; Fee hard caps (bps). Every fee setter rejects values above these.
+;; ============================================
+(define-constant MAX-BORROW-FEE u200)              ;; one-time borrow fee <= 2%
+(define-constant MAX-BORROW-FEE-LP-SHARE u10000)   ;; LP slice of the fee <= 100%
+(define-constant MAX-PROTOCOL-LIQ-SHARE u5000)     ;; protocol cut of penalty <= 50%
+(define-constant MAX-EARLY-REPAY u200)             ;; optional early-repay fee <= 2%
+
+;; ============================================
+;; Recorded launch decision (acceptance: explicit, recorded pre-deploy).
+;; ============================================
+;; LP baseline-incentive dial. LAUNCH VALUE = u0: pure liquidation-only model
+;; (LPs earn solely from the liquidation discount; the whole borrow fee goes to
+;; the protocol). This is the key economic dial and is governance-settable post
+;; launch via set-fee-config -- the u0 here only documents the launch decision;
+;; the value actually stored per market is whatever register-market is called
+;; with. See docs/SSE-Finance-Architecture.md (LP incentive knob).
+(define-constant LAUNCH-BORROW-FEE-LP-SHARE-BPS u0)
+
+;; ============================================
+;; Error Constants
+;; ============================================
+(define-constant ERR_UNAUTHORIZED u800)
+(define-constant ERR_BOOTSTRAP_LOCKED u801)
+(define-constant ERR_MARKET_NOT_FOUND u802)
+(define-constant ERR_FEE_TOO_HIGH u803)
+
+;; ============================================
+;; Governance (mirrors collateral-registry-v6 / price-oracle-pegged-usd-v1)
+;; ============================================
+(define-data-var governance principal CONTRACT-OWNER)
+(define-data-var bootstrap-locked bool false)
+
+(define-read-only (get-governance) (var-get governance))
+(define-read-only (is-bootstrap-locked) (var-get bootstrap-locked))
+
+(define-public (bootstrap-set-governance (new-gov principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (asserts! (not (var-get bootstrap-locked)) (err ERR_BOOTSTRAP_LOCKED))
+    (var-set governance new-gov)
+    (ok true)
+  )
+)
+
+(define-public (lock-bootstrap)
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (var-set bootstrap-locked true)
+    (ok true)
+  )
+)
+
+(define-private (is-governance-caller)
+  (or
+    (is-eq contract-caller (var-get governance))
+    (and (not (var-get bootstrap-locked)) (is-eq tx-sender CONTRACT-OWNER))
+  )
+)
+
+;; ============================================
+;; Data Maps
+;; ============================================
+
+;; Market wiring. market-id is sequential from u0 and doubles as the
+;; enumeration index, so 0..(market-count-1) enumerates every market.
+;; NOTE: no reserve-factor / interest field -- interest-free by design.
+(define-data-var market-count uint u0)
+(define-map markets
+  {market-id: uint}
+  {
+    borrow-token: principal,
+    oracle: principal,
+    borrow-cap: uint,
+    enabled: bool,
+    paused: bool
+  }
+)
+
+;; Fee config lives in its OWN map so fees are updatable independently of market
+;; wiring. All four fields are bps and bounded by the MAX-* caps above.
+(define-map fee-config
+  {market-id: uint}
+  {
+    borrow-fee-bps: uint,
+    borrow-fee-lp-share-bps: uint,
+    protocol-liq-share-bps: uint,
+    early-repay-fee-bps: uint
+  }
+)
+
+;; Treasury recipient for swept protocol fees (governance-set).
+(define-data-var treasury principal CONTRACT-OWNER)
+
+;; Lazily-accrued, not-yet-swept protocol fees per {market, token}.
+(define-map treasury-accrued
+  {market-id: uint, token: principal}
+  {amount: uint}
+)
+
+;; Authorized callers (the vault / pool) allowed to record fee accrual.
+(define-map authorized-callers principal bool)
+
+(define-private (is-authorized-caller)
+  (default-to false (map-get? authorized-callers contract-caller))
+)
+
+;; ============================================
+;; Internal validation
+;; ============================================
+
+;; True iff every fee field is at/under its hard cap.
+(define-private (fees-within-caps
+    (borrow-fee uint)
+    (lp-share uint)
+    (liq-share uint)
+    (early uint)
+  )
+  (and
+    (<= borrow-fee MAX-BORROW-FEE)
+    (<= lp-share MAX-BORROW-FEE-LP-SHARE)
+    (<= liq-share MAX-PROTOCOL-LIQ-SHARE)
+    (<= early MAX-EARLY-REPAY)
+  )
+)
+
+;; ============================================
+;; Market CRUD (governance-gated)
+;; ============================================
+
+;; Register a new borrowable stablecoin market. The single standard import path.
+;; Seeds both the market wiring and its fee-config atomically; returns the new
+;; market-id. Fees are validated against the hard caps before anything is stored.
+(define-public (register-market
+    (borrow-token principal)
+    (oracle principal)
+    (borrow-cap uint)
+    (borrow-fee-bps uint)
+    (borrow-fee-lp-share-bps uint)
+    (protocol-liq-share-bps uint)
+    (early-repay-fee-bps uint)
+  )
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (asserts!
+      (fees-within-caps borrow-fee-bps borrow-fee-lp-share-bps protocol-liq-share-bps early-repay-fee-bps)
+      (err ERR_FEE_TOO_HIGH)
+    )
+    (let ((market-id (var-get market-count)))
+      (map-set markets
+        {market-id: market-id}
+        {
+          borrow-token: borrow-token,
+          oracle: oracle,
+          borrow-cap: borrow-cap,
+          enabled: true,
+          paused: false
+        }
+      )
+      (map-set fee-config
+        {market-id: market-id}
+        {
+          borrow-fee-bps: borrow-fee-bps,
+          borrow-fee-lp-share-bps: borrow-fee-lp-share-bps,
+          protocol-liq-share-bps: protocol-liq-share-bps,
+          early-repay-fee-bps: early-repay-fee-bps
+        }
+      )
+      (var-set market-count (+ market-id u1))
+      (print {
+        event: "market-registered",
+        market-id: market-id,
+        borrow-token: borrow-token,
+        oracle: oracle,
+        borrow-cap: borrow-cap
+      })
+      (ok market-id)
+    )
+  )
+)
+
+;; Update a market's wiring (token, oracle, cap, enabled). Does NOT touch fees
+;; (use set-fee-config) or the paused flag (use set-market-paused). Re-pointing
+;; the oracle here lets a market move to a different oracle principal -- e.g. a
+;; live feed -- with no redeploy.
+(define-public (update-market
+    (market-id uint)
+    (borrow-token principal)
+    (oracle principal)
+    (borrow-cap uint)
+    (enabled bool)
+  )
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (match (map-get? markets {market-id: market-id})
+      market
+        (begin
+          (map-set markets
+            {market-id: market-id}
+            (merge market {
+              borrow-token: borrow-token,
+              oracle: oracle,
+              borrow-cap: borrow-cap,
+              enabled: enabled
+            })
+          )
+          (print {event: "market-updated", market-id: market-id, oracle: oracle, enabled: enabled})
+          (ok true)
+        )
+      (err ERR_MARKET_NOT_FOUND)
+    )
+  )
+)
+
+;; Pause / un-pause a market without disturbing its wiring or fees.
+(define-public (set-market-paused (market-id uint) (paused bool))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (match (map-get? markets {market-id: market-id})
+      market
+        (begin
+          (map-set markets {market-id: market-id} (merge market {paused: paused}))
+          (print {event: "market-paused-changed", market-id: market-id, paused: paused})
+          (ok true)
+        )
+      (err ERR_MARKET_NOT_FOUND)
+    )
+  )
+)
+
+;; ============================================
+;; Fee config (governance-gated, independent of market wiring)
+;; ============================================
+
+;; Replace a market's whole fee-config. Every field is bounded: this is the fee
+;; setter that "rejects values above hard caps". borrow-fee-lp-share-bps (the LP
+;; baseline-incentive dial) is settable here. Market must already exist.
+(define-public (set-fee-config
+    (market-id uint)
+    (borrow-fee-bps uint)
+    (borrow-fee-lp-share-bps uint)
+    (protocol-liq-share-bps uint)
+    (early-repay-fee-bps uint)
+  )
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (asserts! (is-some (map-get? markets {market-id: market-id})) (err ERR_MARKET_NOT_FOUND))
+    (asserts!
+      (fees-within-caps borrow-fee-bps borrow-fee-lp-share-bps protocol-liq-share-bps early-repay-fee-bps)
+      (err ERR_FEE_TOO_HIGH)
+    )
+    (map-set fee-config
+      {market-id: market-id}
+      {
+        borrow-fee-bps: borrow-fee-bps,
+        borrow-fee-lp-share-bps: borrow-fee-lp-share-bps,
+        protocol-liq-share-bps: protocol-liq-share-bps,
+        early-repay-fee-bps: early-repay-fee-bps
+      }
+    )
+    (print {event: "fee-config-updated", market-id: market-id, borrow-fee-bps: borrow-fee-bps})
+    (ok true)
+  )
+)
+
+;; ============================================
+;; Treasury (governance-gated recipient; authorized-caller accrual)
+;; ============================================
+
+(define-public (set-treasury (new-treasury principal))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (var-set treasury new-treasury)
+    (print {event: "treasury-changed", treasury: new-treasury})
+    (ok true)
+  )
+)
+
+;; Record protocol fee accrual. Called only by an authorized caller (vault/pool),
+;; not governance -- it runs during normal borrow/liquidate flows.
+(define-public (accrue-fee (market-id uint) (token principal) (amount uint))
+  (begin
+    (asserts! (is-authorized-caller) (err ERR_UNAUTHORIZED))
+    (let ((new-amount (+ (get-treasury-accrued market-id token) amount)))
+      (map-set treasury-accrued {market-id: market-id, token: token} {amount: new-amount})
+      (ok new-amount)
+    )
+  )
+)
+
+;; Zero a {market, token} accrual and return the amount cleared (for the sweep
+;; contract to move to treasury). Authorized callers only.
+(define-public (clear-treasury-accrued (market-id uint) (token principal))
+  (begin
+    (asserts! (is-authorized-caller) (err ERR_UNAUTHORIZED))
+    (let ((amount (get-treasury-accrued market-id token)))
+      (map-set treasury-accrued {market-id: market-id, token: token} {amount: u0})
+      (ok amount)
+    )
+  )
+)
+
+;; ============================================
+;; Authorized callers (governance-gated)
+;; ============================================
+
+(define-public (set-authorized-caller (caller principal) (authorized bool))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (map-set authorized-callers caller authorized)
+    (print {event: "authorized-caller-changed", caller: caller, authorized: authorized})
+    (ok true)
+  )
+)
+
+;; ============================================
+;; Read-Only Functions
+;; ============================================
+
+(define-read-only (get-market (market-id uint))
+  (map-get? markets {market-id: market-id})
+)
+
+(define-read-only (get-fee-config (market-id uint))
+  (map-get? fee-config {market-id: market-id})
+)
+
+(define-read-only (get-market-count) (var-get market-count))
+
+(define-read-only (get-borrow-token (market-id uint))
+  (match (map-get? markets {market-id: market-id}) market (some (get borrow-token market)) none)
+)
+
+(define-read-only (get-oracle (market-id uint))
+  (match (map-get? markets {market-id: market-id}) market (some (get oracle market)) none)
+)
+
+(define-read-only (get-borrow-cap (market-id uint))
+  (match (map-get? markets {market-id: market-id}) market (some (get borrow-cap market)) none)
+)
+
+(define-read-only (is-market-enabled (market-id uint))
+  (match (map-get? markets {market-id: market-id}) market (get enabled market) false)
+)
+
+(define-read-only (is-market-paused (market-id uint))
+  (match (map-get? markets {market-id: market-id}) market (get paused market) false)
+)
+
+;; A market is active for new borrows only when enabled AND not paused.
+(define-read-only (is-market-active (market-id uint))
+  (match (map-get? markets {market-id: market-id})
+    market (and (get enabled market) (not (get paused market)))
+    false
+  )
+)
+
+(define-read-only (get-treasury) (var-get treasury))
+
+(define-read-only (get-treasury-accrued (market-id uint) (token principal))
+  (default-to u0 (get amount (map-get? treasury-accrued {market-id: market-id, token: token})))
+)
+
+(define-read-only (is-caller-authorized (caller principal))
+  (default-to false (map-get? authorized-callers caller))
+)
+
+;; The immutable hard caps, exposed so off-chain/UI can pre-validate fee inputs.
+(define-read-only (get-fee-caps)
+  {
+    max-borrow-fee: MAX-BORROW-FEE,
+    max-borrow-fee-lp-share: MAX-BORROW-FEE-LP-SHARE,
+    max-protocol-liq-share: MAX-PROTOCOL-LIQ-SHARE,
+    max-early-repay: MAX-EARLY-REPAY
+  }
+)

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -182,6 +182,11 @@ plan:
             path: contracts/sbtc-token-v4.clar
             clarity-version: 3
         - emulated-contract-publish:
+            contract-name: sse-finance-market-registry-v1
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/sse-finance-market-registry-v1.clar
+            clarity-version: 3
+        - emulated-contract-publish:
             contract-name: sse-finance-sip-010-trait
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/sse-finance-sip-010-trait.clar
@@ -191,14 +196,14 @@ plan:
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/sse-governance-v1.clar
             clarity-version: 3
+      epoch: "3.1"
+    - id: 2
+      transactions:
         - emulated-contract-publish:
             contract-name: xreserve-adapter-v5
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/xreserve-adapter-v5.clar
             clarity-version: 3
-      epoch: "3.1"
-    - id: 2
-      transactions:
         - emulated-contract-publish:
             contract-name: sse-timelock-v1
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM

--- a/docs/SSE-Finance-Architecture.md
+++ b/docs/SSE-Finance-Architecture.md
@@ -162,6 +162,14 @@ Setters `asserts!` against these; values can move freely *below* the cap.
 **No interest-based reserve factor** — the protocol is interest-free, so there is no interest to skim;
 all protocol revenue is the one-time borrow fee + the liquidation-penalty cut.
 
+**Recorded launch decision — `borrow-fee-lp-share-bps = u0` (pure liquidation-only).** The LP
+baseline-incentive dial launches at **0**: the whole one-time borrow fee accrues to the protocol and
+LPs earn solely from the liquidation discount. This is implemented as the contract constant
+`LAUNCH-BORROW-FEE-LP-SHARE-BPS` in `sse-finance-market-registry-v1` (documentation only — the value
+actually stored per market is whatever `register-market` is called with at onboarding). The dial
+remains governance-settable up to `MAX-BORROW-FEE-LP-SHARE-BPS` via `set-fee-config`, so a baseline LP
+return can be switched on later without a redeploy.
+
 The **collateral↔market matrix** (which collateral is allowed for which market, and at what ratio)
 reuses the existing per-stablecoin override mechanism in `collateral-registry-v6`
 (`stablecoin-collateral-configs` keyed by `{stablecoin-id, asset}` → here `{market-id, asset}`).

--- a/docs/sse-finance-trait-imports.md
+++ b/docs/sse-finance-trait-imports.md
@@ -16,7 +16,7 @@ externally-deployed trait contract.
 | Contract | `impl-trait` | `use-trait` |
 |---|---|---|
 | `price-oracle-pegged-usd-v1` | `sse-finance-oracle-trait` | — |
-| `sse-finance-market-registry-v1` *(later)* | — | `sse-finance-oracle-trait` (market oracle), `sse-finance-sip-010-trait` (borrow token) |
+| `sse-finance-market-registry-v1` | — | — (stores `borrow-token` & `oracle` as **plain principals**, mirroring how `collateral-registry-v6` stores its oracle; trait typing happens at the vault/pool call sites that actually invoke `transfer` / `get-price`) |
 | `sse-finance-pool-v1` *(later)* | — | `sse-finance-sip-010-trait` (borrow token) |
 | `sse-finance-vault-v1` *(later)* | — | `sse-finance-sip-010-trait` (collateral), `sse-finance-oracle-trait` (pricing) |
 | `sse-finance-liquidation-v1` *(later)* | — | `sse-finance-sip-010-trait`, `sse-finance-oracle-trait` |

--- a/tests/sse-finance-market-registry.test.ts
+++ b/tests/sse-finance-market-registry.test.ts
@@ -1,0 +1,492 @@
+// Full-coverage tests for sse-finance-market-registry-v1: the standard import
+// path by which any SIP-010 stablecoin becomes a borrowable market.
+//
+// Exercises every public + read-only function and every branch:
+//   - register-market / update-market / set-market-paused (happy + not-found),
+//   - the separate fee-config map, independently updatable, with hard-cap
+//     rejection on every fee field (at cap = ok, one tick over = err),
+//   - enumerable market list (sequential ids, get-market-count / get-market),
+//   - treasury recipient (governance) + treasury-accrued accrual/clear gated to
+//     authorized callers,
+//   - all three is-governance-caller branches and the authorized-caller gate,
+//   - the no-reserve-factor / interest-free invariant (no such field exists).
+
+import { describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+const REG = "sse-finance-market-registry-v1";
+
+// Error codes (must match the contract).
+const ERR_UNAUTHORIZED = 800;
+const ERR_BOOTSTRAP_LOCKED = 801;
+const ERR_MARKET_NOT_FOUND = 802;
+const ERR_FEE_TOO_HIGH = 803;
+
+// Hard caps (must match the contract).
+const MAX_BORROW_FEE = 200;
+const MAX_BORROW_FEE_LP_SHARE = 10000;
+const MAX_PROTOCOL_LIQ_SHARE = 5000;
+const MAX_EARLY_REPAY = 200;
+
+function accounts() {
+  const a = simnet.getAccounts();
+  const deployer = a.get("deployer")!;
+  const wallet1 = a.get("wallet_1")!;
+  const wallet2 = a.get("wallet_2")!;
+  const wallet3 = a.get("wallet_3")!;
+  return { deployer, wallet1, wallet2, wallet3 };
+}
+
+// Stand-in principals for a borrow token and an oracle. The registry only stores
+// these, so any principal serves for registry-level tests.
+function fixtures() {
+  const { wallet1, wallet2 } = accounts();
+  return { token: wallet1, oracle: wallet2 };
+}
+
+// Launch fee defaults: borrow fee 0.5% (50 bps), LP share 0 (liq-only launch
+// decision), protocol liq share 20% (2000 bps), no early-repay fee.
+const FEES = { borrow: 50, lpShare: 0, liqShare: 2000, early: 0 };
+
+const registerMarket = (
+  caller: string,
+  token: string,
+  oracle: string,
+  cap: number,
+  fees = FEES
+) =>
+  simnet.callPublicFn(
+    REG,
+    "register-market",
+    [
+      Cl.principal(token),
+      Cl.principal(oracle),
+      Cl.uint(cap),
+      Cl.uint(fees.borrow),
+      Cl.uint(fees.lpShare),
+      Cl.uint(fees.liqShare),
+      Cl.uint(fees.early),
+    ],
+    caller
+  );
+
+const setFeeConfig = (caller: string, id: number, fees: typeof FEES) =>
+  simnet.callPublicFn(
+    REG,
+    "set-fee-config",
+    [
+      Cl.uint(id),
+      Cl.uint(fees.borrow),
+      Cl.uint(fees.lpShare),
+      Cl.uint(fees.liqShare),
+      Cl.uint(fees.early),
+    ],
+    caller
+  );
+
+const read = (fn: string, args: any[], caller: string) =>
+  simnet.callReadOnlyFn(REG, fn, args, caller);
+
+// Field dict of a plain (response/bare) tuple CV.
+const tupleFields = (res: any) => res.value;
+// Field dict of an (optional tuple) CV: unwrap the `some`, then the tuple.
+const someTupleFields = (res: any) => res.value.value;
+const marketFields = (id: number, caller: string) =>
+  someTupleFields(read("get-market", [Cl.uint(id)], caller).result);
+const feeFields = (id: number, caller: string) =>
+  someTupleFields(read("get-fee-config", [Cl.uint(id)], caller).result);
+
+describe("market-registry: initial state", () => {
+  it("defaults: zero markets, governance=deployer, unlocked, treasury=deployer", () => {
+    const { deployer } = accounts();
+    expect(read("get-market-count", [], deployer).result).toBeUint(0);
+    expect(read("get-governance", [], deployer).result).toBePrincipal(deployer);
+    expect(read("is-bootstrap-locked", [], deployer).result).toBeBool(false);
+    expect(read("get-treasury", [], deployer).result).toBePrincipal(deployer);
+    expect(read("get-market", [Cl.uint(0)], deployer).result).toBeNone();
+    expect(read("get-fee-config", [Cl.uint(0)], deployer).result).toBeNone();
+  });
+
+  it("exposes the immutable fee caps", () => {
+    const { deployer } = accounts();
+    const caps = tupleFields(read("get-fee-caps", [], deployer).result);
+    expect(caps["max-borrow-fee"]).toBeUint(MAX_BORROW_FEE);
+    expect(caps["max-borrow-fee-lp-share"]).toBeUint(MAX_BORROW_FEE_LP_SHARE);
+    expect(caps["max-protocol-liq-share"]).toBeUint(MAX_PROTOCOL_LIQ_SHARE);
+    expect(caps["max-early-repay"]).toBeUint(MAX_EARLY_REPAY);
+  });
+});
+
+describe("market-registry: register + read back + enumeration", () => {
+  it("registers a market, returns id 0, and reads it back", () => {
+    const { deployer } = accounts();
+    const { token, oracle } = fixtures();
+    expect(registerMarket(deployer, token, oracle, 1_000_000).result).toBeOk(Cl.uint(0));
+
+    expect(read("get-market-count", [], deployer).result).toBeUint(1);
+    const m = marketFields(0, deployer);
+    expect(m["borrow-token"]).toBePrincipal(token);
+    expect(m["oracle"]).toBePrincipal(oracle);
+    expect(m["borrow-cap"]).toBeUint(1_000_000);
+    expect(m["enabled"]).toBeBool(true);
+    expect(m["paused"]).toBeBool(false);
+
+    // convenience getters
+    expect(read("get-borrow-token", [Cl.uint(0)], deployer).result).toBeSome(Cl.principal(token));
+    expect(read("get-oracle", [Cl.uint(0)], deployer).result).toBeSome(Cl.principal(oracle));
+    expect(read("get-borrow-cap", [Cl.uint(0)], deployer).result).toBeSome(Cl.uint(1_000_000));
+    expect(read("is-market-enabled", [Cl.uint(0)], deployer).result).toBeBool(true);
+    expect(read("is-market-paused", [Cl.uint(0)], deployer).result).toBeBool(false);
+    expect(read("is-market-active", [Cl.uint(0)], deployer).result).toBeBool(true);
+  });
+
+  it("assigns sequential ids and the list enumerates every market", () => {
+    const { deployer, wallet1, wallet2, wallet3 } = accounts();
+    expect(registerMarket(deployer, wallet1, wallet2, 100).result).toBeOk(Cl.uint(0));
+    expect(registerMarket(deployer, wallet2, wallet3, 200).result).toBeOk(Cl.uint(1));
+    expect(registerMarket(deployer, wallet3, wallet1, 300).result).toBeOk(Cl.uint(2));
+
+    expect(read("get-market-count", [], deployer).result).toBeUint(3);
+    for (let id = 0; id < 3; id++) {
+      expect(read("get-market", [Cl.uint(id)], deployer).result).not.toBeNone();
+    }
+  });
+
+  it("seeds the fee-config from register-market (launch LP share = 0)", () => {
+    const { deployer } = accounts();
+    const { token, oracle } = fixtures();
+    registerMarket(deployer, token, oracle, 100);
+    const fc = feeFields(0, deployer);
+    expect(fc["borrow-fee-bps"]).toBeUint(FEES.borrow);
+    expect(fc["borrow-fee-lp-share-bps"]).toBeUint(0);
+    expect(fc["protocol-liq-share-bps"]).toBeUint(FEES.liqShare);
+    expect(fc["early-repay-fee-bps"]).toBeUint(FEES.early);
+    // INTEREST-FREE: no reserve-factor / interest / index field exists.
+    expect(fc["reserve-factor-bps"]).toBeUndefined();
+    expect(fc["interest-rate-bps"]).toBeUndefined();
+  });
+});
+
+describe("market-registry: register-market fee caps", () => {
+  it("accepts every fee exactly at its cap", () => {
+    const { deployer } = accounts();
+    const { token, oracle } = fixtures();
+    expect(
+      registerMarket(deployer, token, oracle, 100, {
+        borrow: MAX_BORROW_FEE,
+        lpShare: MAX_BORROW_FEE_LP_SHARE,
+        liqShare: MAX_PROTOCOL_LIQ_SHARE,
+        early: MAX_EARLY_REPAY,
+      }).result
+    ).toBeOk(Cl.uint(0));
+  });
+
+  it("rejects each fee one tick above its cap and stores nothing", () => {
+    const { deployer } = accounts();
+    const { token, oracle } = fixtures();
+    const over = [
+      { ...FEES, borrow: MAX_BORROW_FEE + 1 },
+      { ...FEES, lpShare: MAX_BORROW_FEE_LP_SHARE + 1 },
+      { ...FEES, liqShare: MAX_PROTOCOL_LIQ_SHARE + 1 },
+      { ...FEES, early: MAX_EARLY_REPAY + 1 },
+    ];
+    for (const fees of over) {
+      expect(registerMarket(deployer, token, oracle, 100, fees).result).toBeErr(
+        Cl.uint(ERR_FEE_TOO_HIGH)
+      );
+    }
+    // nothing was registered
+    expect(read("get-market-count", [], deployer).result).toBeUint(0);
+  });
+});
+
+describe("market-registry: update-market", () => {
+  it("updates wiring (token, oracle, cap, enabled) without touching fees/paused", () => {
+    const { deployer, wallet3 } = accounts();
+    const { token, oracle } = fixtures();
+    registerMarket(deployer, token, oracle, 100);
+    // pause first; update-market must leave paused untouched
+    simnet.callPublicFn(REG, "set-market-paused", [Cl.uint(0), Cl.bool(true)], deployer);
+
+    expect(
+      simnet.callPublicFn(
+        REG,
+        "update-market",
+        [Cl.uint(0), Cl.principal(wallet3), Cl.principal(wallet3), Cl.uint(999), Cl.bool(false)],
+        deployer
+      ).result
+    ).toBeOk(Cl.bool(true));
+
+    const m = marketFields(0, deployer);
+    expect(m["oracle"]).toBePrincipal(wallet3); // re-pointed oracle
+    expect(m["borrow-cap"]).toBeUint(999);
+    expect(m["enabled"]).toBeBool(false);
+    expect(m["paused"]).toBeBool(true); // preserved
+    // fees untouched
+    expect(feeFields(0, deployer)["borrow-fee-bps"]).toBeUint(FEES.borrow);
+  });
+
+  it("reverts on a non-existent market", () => {
+    const { deployer, wallet3 } = accounts();
+    expect(
+      simnet.callPublicFn(
+        REG,
+        "update-market",
+        [Cl.uint(7), Cl.principal(wallet3), Cl.principal(wallet3), Cl.uint(1), Cl.bool(true)],
+        deployer
+      ).result
+    ).toBeErr(Cl.uint(ERR_MARKET_NOT_FOUND));
+  });
+});
+
+describe("market-registry: set-market-paused", () => {
+  it("pauses and un-pauses; is-market-active reflects it", () => {
+    const { deployer } = accounts();
+    const { token, oracle } = fixtures();
+    registerMarket(deployer, token, oracle, 100);
+
+    expect(
+      simnet.callPublicFn(REG, "set-market-paused", [Cl.uint(0), Cl.bool(true)], deployer).result
+    ).toBeOk(Cl.bool(true));
+    expect(read("is-market-paused", [Cl.uint(0)], deployer).result).toBeBool(true);
+    expect(read("is-market-active", [Cl.uint(0)], deployer).result).toBeBool(false);
+    // still enabled -- pause is independent of enabled
+    expect(read("is-market-enabled", [Cl.uint(0)], deployer).result).toBeBool(true);
+
+    simnet.callPublicFn(REG, "set-market-paused", [Cl.uint(0), Cl.bool(false)], deployer);
+    expect(read("is-market-active", [Cl.uint(0)], deployer).result).toBeBool(true);
+  });
+
+  it("reverts on a non-existent market", () => {
+    const { deployer } = accounts();
+    expect(
+      simnet.callPublicFn(REG, "set-market-paused", [Cl.uint(9), Cl.bool(true)], deployer).result
+    ).toBeErr(Cl.uint(ERR_MARKET_NOT_FOUND));
+  });
+});
+
+describe("market-registry: set-fee-config (independent of wiring)", () => {
+  it("updates fees without touching the market wiring", () => {
+    const { deployer } = accounts();
+    const { token, oracle } = fixtures();
+    registerMarket(deployer, token, oracle, 100);
+
+    // raise the LP baseline-incentive dial post-launch
+    expect(setFeeConfig(deployer, 0, { borrow: 100, lpShare: 3000, liqShare: 4000, early: 25 }).result)
+      .toBeOk(Cl.bool(true));
+
+    const fc = feeFields(0, deployer);
+    expect(fc["borrow-fee-bps"]).toBeUint(100);
+    expect(fc["borrow-fee-lp-share-bps"]).toBeUint(3000);
+    expect(fc["protocol-liq-share-bps"]).toBeUint(4000);
+    expect(fc["early-repay-fee-bps"]).toBeUint(25);
+
+    // market wiring unchanged
+    const m = marketFields(0, deployer);
+    expect(m["borrow-token"]).toBePrincipal(token);
+    expect(m["oracle"]).toBePrincipal(oracle);
+    expect(m["borrow-cap"]).toBeUint(100);
+  });
+
+  it("accepts every fee at its cap", () => {
+    const { deployer } = accounts();
+    const { token, oracle } = fixtures();
+    registerMarket(deployer, token, oracle, 100);
+    expect(
+      setFeeConfig(deployer, 0, {
+        borrow: MAX_BORROW_FEE,
+        lpShare: MAX_BORROW_FEE_LP_SHARE,
+        liqShare: MAX_PROTOCOL_LIQ_SHARE,
+        early: MAX_EARLY_REPAY,
+      }).result
+    ).toBeOk(Cl.bool(true));
+  });
+
+  it("rejects each fee one tick over its cap", () => {
+    const { deployer } = accounts();
+    const { token, oracle } = fixtures();
+    registerMarket(deployer, token, oracle, 100);
+    const over = [
+      { ...FEES, borrow: MAX_BORROW_FEE + 1 },
+      { ...FEES, lpShare: MAX_BORROW_FEE_LP_SHARE + 1 },
+      { ...FEES, liqShare: MAX_PROTOCOL_LIQ_SHARE + 1 },
+      { ...FEES, early: MAX_EARLY_REPAY + 1 },
+    ];
+    for (const fees of over) {
+      expect(setFeeConfig(deployer, 0, fees).result).toBeErr(Cl.uint(ERR_FEE_TOO_HIGH));
+    }
+  });
+
+  it("reverts on a non-existent market", () => {
+    const { deployer } = accounts();
+    expect(setFeeConfig(deployer, 3, FEES).result).toBeErr(Cl.uint(ERR_MARKET_NOT_FOUND));
+  });
+});
+
+describe("market-registry: governance gating", () => {
+  it("non-governance cannot register / update / pause / set fees / set treasury / authorize", () => {
+    const { deployer, wallet2, wallet3 } = accounts();
+    const { token, oracle } = fixtures();
+    registerMarket(deployer, token, oracle, 100); // exists as id 0
+
+    expect(registerMarket(wallet3, token, oracle, 100).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(
+      simnet.callPublicFn(
+        REG,
+        "update-market",
+        [Cl.uint(0), Cl.principal(token), Cl.principal(oracle), Cl.uint(1), Cl.bool(true)],
+        wallet3
+      ).result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(
+      simnet.callPublicFn(REG, "set-market-paused", [Cl.uint(0), Cl.bool(true)], wallet3).result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(setFeeConfig(wallet3, 0, FEES).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(
+      simnet.callPublicFn(REG, "set-treasury", [Cl.principal(wallet2)], wallet3).result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(
+      simnet.callPublicFn(
+        REG,
+        "set-authorized-caller",
+        [Cl.principal(wallet2), Cl.bool(true)],
+        wallet3
+      ).result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+  });
+
+  it("after handoff + lock, the pre-lock owner loses access; new governance keeps it", () => {
+    const { deployer, wallet1, wallet2 } = accounts();
+    const { token, oracle } = fixtures();
+    // hand governance to wallet1, then lock bootstrap
+    expect(
+      simnet.callPublicFn(REG, "bootstrap-set-governance", [Cl.principal(wallet1)], deployer).result
+    ).toBeOk(Cl.bool(true));
+    expect(simnet.callPublicFn(REG, "lock-bootstrap", [], deployer).result).toBeOk(Cl.bool(true));
+
+    // deployer (owner) no longer governance and bootstrap locked -> rejected
+    expect(registerMarket(deployer, token, oracle, 100).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    // random principal -> rejected
+    expect(registerMarket(wallet2, token, oracle, 100).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    // governance (wallet1, contract-caller branch) -> ok
+    expect(registerMarket(wallet1, token, oracle, 100).result).toBeOk(Cl.uint(0));
+  });
+
+  it("bootstrap-set-governance / lock-bootstrap reject non-owner; set-gov rejects once locked", () => {
+    const { deployer, wallet2 } = accounts();
+    expect(
+      simnet.callPublicFn(REG, "bootstrap-set-governance", [Cl.principal(wallet2)], wallet2).result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(simnet.callPublicFn(REG, "lock-bootstrap", [], wallet2).result).toBeErr(
+      Cl.uint(ERR_UNAUTHORIZED)
+    );
+    expect(simnet.callPublicFn(REG, "lock-bootstrap", [], deployer).result).toBeOk(Cl.bool(true));
+    expect(
+      simnet.callPublicFn(REG, "bootstrap-set-governance", [Cl.principal(wallet2)], deployer).result
+    ).toBeErr(Cl.uint(ERR_BOOTSTRAP_LOCKED));
+  });
+});
+
+describe("market-registry: treasury + accrual", () => {
+  it("governance sets the treasury recipient", () => {
+    const { deployer, wallet3 } = accounts();
+    expect(
+      simnet.callPublicFn(REG, "set-treasury", [Cl.principal(wallet3)], deployer).result
+    ).toBeOk(Cl.bool(true));
+    expect(read("get-treasury", [], deployer).result).toBePrincipal(wallet3);
+  });
+
+  it("accrue-fee / clear-treasury-accrued are gated to authorized callers", () => {
+    const { deployer, wallet1, wallet3 } = accounts();
+    const { token } = fixtures();
+    // not authorized yet
+    expect(
+      simnet.callPublicFn(
+        REG,
+        "accrue-fee",
+        [Cl.uint(0), Cl.principal(token), Cl.uint(500)],
+        wallet3
+      ).result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+
+    // authorize wallet3 as a caller (stands in for the vault/pool)
+    expect(
+      simnet.callPublicFn(
+        REG,
+        "set-authorized-caller",
+        [Cl.principal(wallet3), Cl.bool(true)],
+        deployer
+      ).result
+    ).toBeOk(Cl.bool(true));
+    expect(read("is-caller-authorized", [Cl.principal(wallet3)], deployer).result).toBeBool(true);
+
+    // accrue twice -> accumulates
+    expect(
+      simnet.callPublicFn(
+        REG,
+        "accrue-fee",
+        [Cl.uint(0), Cl.principal(token), Cl.uint(500)],
+        wallet3
+      ).result
+    ).toBeOk(Cl.uint(500));
+    expect(
+      simnet.callPublicFn(
+        REG,
+        "accrue-fee",
+        [Cl.uint(0), Cl.principal(token), Cl.uint(250)],
+        wallet3
+      ).result
+    ).toBeOk(Cl.uint(750));
+    expect(
+      read("get-treasury-accrued", [Cl.uint(0), Cl.principal(token)], deployer).result
+    ).toBeUint(750);
+
+    // clear returns the swept amount and zeroes the bucket
+    expect(
+      simnet.callPublicFn(
+        REG,
+        "clear-treasury-accrued",
+        [Cl.uint(0), Cl.principal(token)],
+        wallet3
+      ).result
+    ).toBeOk(Cl.uint(750));
+    expect(
+      read("get-treasury-accrued", [Cl.uint(0), Cl.principal(token)], deployer).result
+    ).toBeUint(0);
+
+    // de-authorize -> rejected again
+    simnet.callPublicFn(
+      REG,
+      "set-authorized-caller",
+      [Cl.principal(wallet3), Cl.bool(false)],
+      deployer
+    );
+    expect(
+      simnet.callPublicFn(
+        REG,
+        "clear-treasury-accrued",
+        [Cl.uint(0), Cl.principal(token)],
+        wallet3
+      ).result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+  });
+
+  it("accrual is isolated per {market, token}", () => {
+    const { deployer, wallet1, wallet2, wallet3 } = accounts();
+    simnet.callPublicFn(
+      REG,
+      "set-authorized-caller",
+      [Cl.principal(wallet3), Cl.bool(true)],
+      deployer
+    );
+    simnet.callPublicFn(REG, "accrue-fee", [Cl.uint(0), Cl.principal(wallet1), Cl.uint(10)], wallet3);
+    simnet.callPublicFn(REG, "accrue-fee", [Cl.uint(1), Cl.principal(wallet1), Cl.uint(20)], wallet3);
+    simnet.callPublicFn(REG, "accrue-fee", [Cl.uint(0), Cl.principal(wallet2), Cl.uint(30)], wallet3);
+
+    expect(read("get-treasury-accrued", [Cl.uint(0), Cl.principal(wallet1)], deployer).result).toBeUint(10);
+    expect(read("get-treasury-accrued", [Cl.uint(1), Cl.principal(wallet1)], deployer).result).toBeUint(20);
+    expect(read("get-treasury-accrued", [Cl.uint(0), Cl.principal(wallet2)], deployer).result).toBeUint(30);
+    // untouched pair reads zero
+    expect(read("get-treasury-accrued", [Cl.uint(2), Cl.principal(wallet1)], deployer).result).toBeUint(0);
+  });
+});


### PR DESCRIPTION

Add sse-finance-market-registry-v1 as the single standard import path for making any SIP-010 stablecoin borrowable. Structure mirrors collateral-registry-v6 with enumerable market list (sequential market-id doubles as enumeration index), per-key market wiring (borrow-token/oracle/cap/enabled/paused) stored separately from per-key fee-config (borrow-fee/lp-share/liq-share/early-repay b