### PR TITLE
feat: add sse-finance-collateral-matrix-v1 with per-market collateralenumeration and governance-gated risk params

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -51,6 +51,13 @@ path = "contracts/sse-finance-market-registry-v1.clar"
 epoch = "3.1"
 depends_on = []
 
+# Collateral<->market risk matrix ("the matrix"): per {market, collateral} risk
+# params. Absence of a row = pair not borrowable. Keyed off registry market-ids.
+[contracts.sse-finance-collateral-matrix-v1]
+path = "contracts/sse-finance-collateral-matrix-v1.clar"
+epoch = "3.1"
+depends_on = ["sse-finance-market-registry-v1"]
+
 # ── Governance ────────────────────────────────────────────────────────────────
 
 [contracts.sse-governance-v1]

--- a/contracts/sse-finance-collateral-matrix-v1.clar
+++ b/contracts/sse-finance-collateral-matrix-v1.clar
@@ -1,0 +1,253 @@
+;; sse-finance-collateral-matrix-v1.clar
+;;
+;; The collateral<->market risk matrix for SSE Finance. A config table answering,
+;; for each {market, collateral} pair: is this collateral accepted to borrow this
+;; stablecoin, and at what risk parameters? One row = one accepted pair; the
+;; ABSENCE of a row means the pair is not borrowable.
+;;
+;; Per-pair parameters (the five risk params), copying the config shape of
+;; collateral-registry-v6's stablecoin-collateral-configs:
+;;   - min-collateral-ratio   (open/withdraw floor, bps of value, > 100)
+;;   - liquidation-ratio      (health threshold, > 100, <= min-collateral-ratio)
+;;   - liquidation-penalty    (bonus collateral seized on liquidation)
+;;   - debt-floor             (minimum debt for a position)
+;;   - debt-ceiling           (per-market cap for THIS collateral)
+;;
+;; market-id is defined by sse-finance-market-registry-v1; add-collateral-to-market
+;; validates the market exists there, so the matrix can never reference a phantom
+;; market. Structure mirrors collateral-registry-v6: enumerable per-market list +
+;; per-key config + governance gate.
+;;
+;; INTEREST-FREE: there is deliberately no stability-fee / interest field here.
+
+(define-constant CONTRACT-OWNER tx-sender)
+
+;; ============================================
+;; Error Constants
+;; ============================================
+(define-constant ERR_UNAUTHORIZED u900)
+(define-constant ERR_BOOTSTRAP_LOCKED u901)
+(define-constant ERR_MARKET_NOT_FOUND u902)
+(define-constant ERR_PAIR_EXISTS u903)
+(define-constant ERR_PAIR_NOT_FOUND u904)
+(define-constant ERR_INVALID_RATIO u905)
+
+;; ============================================
+;; Governance (mirrors the rest of the SSE Finance package)
+;; ============================================
+(define-data-var governance principal CONTRACT-OWNER)
+(define-data-var bootstrap-locked bool false)
+
+(define-read-only (get-governance) (var-get governance))
+(define-read-only (is-bootstrap-locked) (var-get bootstrap-locked))
+
+(define-public (bootstrap-set-governance (new-gov principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (asserts! (not (var-get bootstrap-locked)) (err ERR_BOOTSTRAP_LOCKED))
+    (var-set governance new-gov)
+    (ok true)
+  )
+)
+
+(define-public (lock-bootstrap)
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (var-set bootstrap-locked true)
+    (ok true)
+  )
+)
+
+(define-private (is-governance-caller)
+  (or
+    (is-eq contract-caller (var-get governance))
+    (and (not (var-get bootstrap-locked)) (is-eq tx-sender CONTRACT-OWNER))
+  )
+)
+
+;; ============================================
+;; Data Maps
+;; ============================================
+
+;; The risk row for a {market, collateral} pair. No row = pair not borrowable.
+(define-map risk-configs
+  {market-id: uint, collateral: principal}
+  {
+    min-collateral-ratio: uint,
+    liquidation-ratio: uint,
+    liquidation-penalty: uint,
+    debt-floor: uint,
+    debt-ceiling: uint,
+    enabled: bool
+  }
+)
+
+;; Per-market enumeration of configured collaterals.
+(define-map market-collateral-count {market-id: uint} {count: uint})
+(define-map market-collateral-list {market-id: uint, index: uint} {collateral: principal})
+
+;; ============================================
+;; Internal validation
+;; ============================================
+
+(define-private (ratios-valid (min-ratio uint) (liq-ratio uint))
+  (and
+    (> min-ratio u100)
+    (> liq-ratio u100)
+    (<= liq-ratio min-ratio)
+  )
+)
+
+(define-private (market-exists (market-id uint))
+  (is-some (contract-call? .sse-finance-market-registry-v1 get-market market-id))
+)
+
+;; ============================================
+;; Matrix CRUD (governance-gated)
+;; ============================================
+
+;; Add a new {market, collateral} risk row. Fails if the market does not exist in
+;; the registry, if the pair is already configured, or if the ratios are invalid.
+;; Appends to the per-market enumeration. The row is enabled on creation.
+(define-public (add-collateral-to-market
+    (market-id uint)
+    (collateral principal)
+    (min-collateral-ratio uint)
+    (liquidation-ratio uint)
+    (liquidation-penalty uint)
+    (debt-floor uint)
+    (debt-ceiling uint)
+  )
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (asserts! (market-exists market-id) (err ERR_MARKET_NOT_FOUND))
+    (asserts!
+      (is-none (map-get? risk-configs {market-id: market-id, collateral: collateral}))
+      (err ERR_PAIR_EXISTS)
+    )
+    (asserts! (ratios-valid min-collateral-ratio liquidation-ratio) (err ERR_INVALID_RATIO))
+
+    (map-set risk-configs
+      {market-id: market-id, collateral: collateral}
+      {
+        min-collateral-ratio: min-collateral-ratio,
+        liquidation-ratio: liquidation-ratio,
+        liquidation-penalty: liquidation-penalty,
+        debt-floor: debt-floor,
+        debt-ceiling: debt-ceiling,
+        enabled: true
+      }
+    )
+
+    (let ((current-count (default-to u0 (get count (map-get? market-collateral-count {market-id: market-id})))))
+      (map-set market-collateral-list {market-id: market-id, index: current-count} {collateral: collateral})
+      (map-set market-collateral-count {market-id: market-id} {count: (+ current-count u1)})
+    )
+
+    (print {
+      event: "collateral-added-to-market",
+      market-id: market-id,
+      collateral: collateral,
+      min-collateral-ratio: min-collateral-ratio,
+      liquidation-ratio: liquidation-ratio
+    })
+    (ok true)
+  )
+)
+
+;; Update an existing pair's risk params. Preserves the enabled flag (use
+;; set-pair-enabled to toggle that). Fails if the pair has no row.
+(define-public (update-collateral-risk
+    (market-id uint)
+    (collateral principal)
+    (min-collateral-ratio uint)
+    (liquidation-ratio uint)
+    (liquidation-penalty uint)
+    (debt-floor uint)
+    (debt-ceiling uint)
+  )
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (asserts! (ratios-valid min-collateral-ratio liquidation-ratio) (err ERR_INVALID_RATIO))
+    (match (map-get? risk-configs {market-id: market-id, collateral: collateral})
+      existing
+        (begin
+          (map-set risk-configs
+            {market-id: market-id, collateral: collateral}
+            {
+              min-collateral-ratio: min-collateral-ratio,
+              liquidation-ratio: liquidation-ratio,
+              liquidation-penalty: liquidation-penalty,
+              debt-floor: debt-floor,
+              debt-ceiling: debt-ceiling,
+              enabled: (get enabled existing)
+            }
+          )
+          (print {event: "collateral-risk-updated", market-id: market-id, collateral: collateral})
+          (ok true)
+        )
+      (err ERR_PAIR_NOT_FOUND)
+    )
+  )
+)
+
+;; Enable / disable an existing pair without disturbing its params.
+(define-public (set-pair-enabled (market-id uint) (collateral principal) (enabled bool))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (match (map-get? risk-configs {market-id: market-id, collateral: collateral})
+      existing
+        (begin
+          (map-set risk-configs
+            {market-id: market-id, collateral: collateral}
+            (merge existing {enabled: enabled})
+          )
+          (print {event: "pair-enabled-changed", market-id: market-id, collateral: collateral, enabled: enabled})
+          (ok true)
+        )
+      (err ERR_PAIR_NOT_FOUND)
+    )
+  )
+)
+
+;; ============================================
+;; Read-Only Functions
+;; ============================================
+
+;; The full risk row for a pair (enabled + all five params) in one call. None
+;; means the pair is not borrowable.
+(define-read-only (get-collateral-risk (market-id uint) (collateral principal))
+  (map-get? risk-configs {market-id: market-id, collateral: collateral})
+)
+
+;; True only if the pair has a row AND that row is enabled. Absence => false.
+(define-read-only (is-pair-enabled (market-id uint) (collateral principal))
+  (match (map-get? risk-configs {market-id: market-id, collateral: collateral})
+    config (get enabled config)
+    false
+  )
+)
+
+;; The vault's one-call health-check helper: returns the enabled flag together
+;; with the ratios/penalty/floor/ceiling, or none if the pair is not configured.
+(define-read-only (get-pair-status (market-id uint) (collateral principal))
+  (match (map-get? risk-configs {market-id: market-id, collateral: collateral})
+    config (some {
+      enabled: (get enabled config),
+      min-collateral-ratio: (get min-collateral-ratio config),
+      liquidation-ratio: (get liquidation-ratio config),
+      liquidation-penalty: (get liquidation-penalty config),
+      debt-floor: (get debt-floor config),
+      debt-ceiling: (get debt-ceiling config)
+    })
+    none
+  )
+)
+
+(define-read-only (get-market-collateral-count (market-id uint))
+  (default-to u0 (get count (map-get? market-collateral-count {market-id: market-id})))
+)
+
+(define-read-only (get-market-collateral-at-index (market-id uint) (index uint))
+  (map-get? market-collateral-list {market-id: market-id, index: index})
+)

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -58,7 +58,6 @@ genesis:
     - pox-4
     - signers
     - signers-voting
-    - costs-4
 plan:
   batches:
     - id: 0
@@ -68,7 +67,7 @@ plan:
             emulated-sender: SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE
             path: "./.cache/requirements/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.clar"
             clarity-version: 1
-      epoch: "2.1"
+      epoch: "2.0"
     - id: 1
       transactions:
         - emulated-contract-publish:
@@ -187,18 +186,23 @@ plan:
             path: contracts/sse-finance-market-registry-v1.clar
             clarity-version: 3
         - emulated-contract-publish:
+            contract-name: sse-finance-collateral-matrix-v1
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/sse-finance-collateral-matrix-v1.clar
+            clarity-version: 3
+        - emulated-contract-publish:
             contract-name: sse-finance-sip-010-trait
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/sse-finance-sip-010-trait.clar
             clarity-version: 3
+      epoch: "3.1"
+    - id: 2
+      transactions:
         - emulated-contract-publish:
             contract-name: sse-governance-v1
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/sse-governance-v1.clar
             clarity-version: 3
-      epoch: "3.1"
-    - id: 2
-      transactions:
         - emulated-contract-publish:
             contract-name: xreserve-adapter-v5
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM

--- a/tests/sse-finance-collateral-matrix.test.ts
+++ b/tests/sse-finance-collateral-matrix.test.ts
@@ -1,0 +1,327 @@
+// Full-coverage tests for sse-finance-collateral-matrix-v1: the collateral<->market
+// risk matrix. One row per accepted {market, collateral} pair; absence of a row
+// means the pair is not borrowable.
+//
+// Exercises every public + read-only function and every branch:
+//   - add-collateral-to-market (happy, market-not-found, pair-exists, bad ratios),
+//   - update-collateral-risk (happy preserving enabled, not-found, bad ratios),
+//   - set-pair-enabled (toggle, not-found),
+//   - get-collateral-risk / get-pair-status (all five params in one call) /
+//     is-pair-enabled (absence => false), per-market enumeration,
+//   - governance gating + all three is-governance-caller branches,
+//   - the no-stability-fee / interest-free invariant.
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+const REG = "sse-finance-market-registry-v1";
+const MATRIX = "sse-finance-collateral-matrix-v1";
+
+// Matrix error codes (must match the contract).
+const ERR_UNAUTHORIZED = 900;
+const ERR_BOOTSTRAP_LOCKED = 901;
+const ERR_MARKET_NOT_FOUND = 902;
+const ERR_PAIR_EXISTS = 903;
+const ERR_PAIR_NOT_FOUND = 904;
+const ERR_INVALID_RATIO = 905;
+
+function accounts() {
+  const a = simnet.getAccounts();
+  const deployer = a.get("deployer")!;
+  const wallet1 = a.get("wallet_1")!;
+  const wallet2 = a.get("wallet_2")!;
+  const wallet3 = a.get("wallet_3")!;
+  return { deployer, wallet1, wallet2, wallet3 };
+}
+
+// Stand-in collateral asset principals (the matrix only stores them).
+function collats() {
+  const { wallet1, wallet2 } = accounts();
+  return { sbtc: wallet1, vgld: wallet2 };
+}
+
+// Risk params: 150% min / 120% liq / 10% penalty / floor / ceiling.
+const RISK = { min: 150, liq: 120, penalty: 1000, floor: 100, ceiling: 1_000_000 };
+
+// Register market 0 so the matrix's market-exists check passes.
+function registerMarket0(caller: string) {
+  const { wallet3 } = accounts();
+  return simnet.callPublicFn(
+    REG,
+    "register-market",
+    [
+      Cl.principal(wallet3), // borrow-token (stand-in)
+      Cl.principal(wallet3), // oracle (stand-in)
+      Cl.uint(1_000_000),
+      Cl.uint(50),
+      Cl.uint(0),
+      Cl.uint(2000),
+      Cl.uint(0),
+    ],
+    caller
+  );
+}
+
+const addPair = (
+  caller: string,
+  marketId: number,
+  collateral: string,
+  risk = RISK
+) =>
+  simnet.callPublicFn(
+    MATRIX,
+    "add-collateral-to-market",
+    [
+      Cl.uint(marketId),
+      Cl.principal(collateral),
+      Cl.uint(risk.min),
+      Cl.uint(risk.liq),
+      Cl.uint(risk.penalty),
+      Cl.uint(risk.floor),
+      Cl.uint(risk.ceiling),
+    ],
+    caller
+  );
+
+const updatePair = (
+  caller: string,
+  marketId: number,
+  collateral: string,
+  risk: typeof RISK
+) =>
+  simnet.callPublicFn(
+    MATRIX,
+    "update-collateral-risk",
+    [
+      Cl.uint(marketId),
+      Cl.principal(collateral),
+      Cl.uint(risk.min),
+      Cl.uint(risk.liq),
+      Cl.uint(risk.penalty),
+      Cl.uint(risk.floor),
+      Cl.uint(risk.ceiling),
+    ],
+    caller
+  );
+
+const read = (fn: string, args: any[], caller: string) =>
+  simnet.callReadOnlyFn(MATRIX, fn, args, caller);
+const someTupleFields = (res: any) => res.value.value; // optional<tuple> -> dict
+const riskFields = (id: number, collateral: string, caller: string) =>
+  someTupleFields(read("get-collateral-risk", [Cl.uint(id), Cl.principal(collateral)], caller).result);
+const statusFields = (id: number, collateral: string, caller: string) =>
+  someTupleFields(read("get-pair-status", [Cl.uint(id), Cl.principal(collateral)], caller).result);
+
+describe("collateral-matrix: write + read back all five params", () => {
+  beforeEach(() => registerMarket0(accounts().deployer));
+
+  it("absence of a row means the pair is not borrowable", () => {
+    const { deployer } = accounts();
+    const { sbtc } = collats();
+    expect(read("get-collateral-risk", [Cl.uint(0), Cl.principal(sbtc)], deployer).result).toBeNone();
+    expect(read("get-pair-status", [Cl.uint(0), Cl.principal(sbtc)], deployer).result).toBeNone();
+    expect(read("is-pair-enabled", [Cl.uint(0), Cl.principal(sbtc)], deployer).result).toBeBool(false);
+  });
+
+  it("writes a pair and reads back all five risk params + enabled", () => {
+    const { deployer } = accounts();
+    const { sbtc } = collats();
+    expect(addPair(deployer, 0, sbtc).result).toBeOk(Cl.bool(true));
+
+    const r = riskFields(0, sbtc, deployer);
+    expect(r["min-collateral-ratio"]).toBeUint(RISK.min);
+    expect(r["liquidation-ratio"]).toBeUint(RISK.liq);
+    expect(r["liquidation-penalty"]).toBeUint(RISK.penalty);
+    expect(r["debt-floor"]).toBeUint(RISK.floor);
+    expect(r["debt-ceiling"]).toBeUint(RISK.ceiling);
+    expect(r["enabled"]).toBeBool(true);
+    // INTEREST-FREE: no stability-fee / interest field exists.
+    expect(r["stability-fee"]).toBeUndefined();
+
+    expect(read("is-pair-enabled", [Cl.uint(0), Cl.principal(sbtc)], deployer).result).toBeBool(true);
+  });
+
+  it("get-pair-status returns enabled + all five params in one call", () => {
+    const { deployer } = accounts();
+    const { sbtc } = collats();
+    addPair(deployer, 0, sbtc);
+    const s = statusFields(0, sbtc, deployer);
+    expect(s["enabled"]).toBeBool(true);
+    expect(s["min-collateral-ratio"]).toBeUint(RISK.min);
+    expect(s["liquidation-ratio"]).toBeUint(RISK.liq);
+    expect(s["liquidation-penalty"]).toBeUint(RISK.penalty);
+    expect(s["debt-floor"]).toBeUint(RISK.floor);
+    expect(s["debt-ceiling"]).toBeUint(RISK.ceiling);
+  });
+});
+
+describe("collateral-matrix: add-collateral-to-market guards", () => {
+  beforeEach(() => registerMarket0(accounts().deployer));
+
+  it("rejects a non-existent market", () => {
+    const { deployer } = accounts();
+    const { sbtc } = collats();
+    expect(addPair(deployer, 7, sbtc).result).toBeErr(Cl.uint(ERR_MARKET_NOT_FOUND));
+  });
+
+  it("rejects a duplicate pair", () => {
+    const { deployer } = accounts();
+    const { sbtc } = collats();
+    expect(addPair(deployer, 0, sbtc).result).toBeOk(Cl.bool(true));
+    expect(addPair(deployer, 0, sbtc).result).toBeErr(Cl.uint(ERR_PAIR_EXISTS));
+  });
+
+  it("rejects invalid ratios (min<=100, liq<=100, liq>min)", () => {
+    const { deployer } = accounts();
+    const { sbtc } = collats();
+    expect(addPair(deployer, 0, sbtc, { ...RISK, min: 100 }).result).toBeErr(Cl.uint(ERR_INVALID_RATIO));
+    expect(addPair(deployer, 0, sbtc, { ...RISK, liq: 100 }).result).toBeErr(Cl.uint(ERR_INVALID_RATIO));
+    expect(addPair(deployer, 0, sbtc, { ...RISK, min: 120, liq: 130 }).result).toBeErr(
+      Cl.uint(ERR_INVALID_RATIO)
+    );
+    // nothing was written
+    expect(read("get-collateral-risk", [Cl.uint(0), Cl.principal(sbtc)], deployer).result).toBeNone();
+  });
+
+  it("accepts liq == min (the boundary)", () => {
+    const { deployer } = accounts();
+    const { sbtc } = collats();
+    expect(addPair(deployer, 0, sbtc, { ...RISK, min: 150, liq: 150 }).result).toBeOk(Cl.bool(true));
+  });
+});
+
+describe("collateral-matrix: per-market enumeration", () => {
+  beforeEach(() => registerMarket0(accounts().deployer));
+
+  it("counts and lists every collateral for a market", () => {
+    const { deployer } = accounts();
+    const { sbtc, vgld } = collats();
+    expect(read("get-market-collateral-count", [Cl.uint(0)], deployer).result).toBeUint(0);
+
+    addPair(deployer, 0, sbtc);
+    addPair(deployer, 0, vgld);
+
+    expect(read("get-market-collateral-count", [Cl.uint(0)], deployer).result).toBeUint(2);
+    expect(
+      someTupleFields(read("get-market-collateral-at-index", [Cl.uint(0), Cl.uint(0)], deployer).result)["collateral"]
+    ).toBePrincipal(sbtc);
+    expect(
+      someTupleFields(read("get-market-collateral-at-index", [Cl.uint(0), Cl.uint(1)], deployer).result)["collateral"]
+    ).toBePrincipal(vgld);
+    // out-of-range index
+    expect(read("get-market-collateral-at-index", [Cl.uint(0), Cl.uint(2)], deployer).result).toBeNone();
+  });
+});
+
+describe("collateral-matrix: update-collateral-risk", () => {
+  beforeEach(() => {
+    const { deployer } = accounts();
+    registerMarket0(deployer);
+    addPair(deployer, 0, collats().sbtc);
+  });
+
+  it("updates params and preserves the enabled flag", () => {
+    const { deployer } = accounts();
+    const { sbtc } = collats();
+    // disable first; update must preserve the disabled state
+    simnet.callPublicFn(MATRIX, "set-pair-enabled", [Cl.uint(0), Cl.principal(sbtc), Cl.bool(false)], deployer);
+
+    const next = { min: 160, liq: 125, penalty: 800, floor: 50, ceiling: 2_000_000 };
+    expect(updatePair(deployer, 0, sbtc, next).result).toBeOk(Cl.bool(true));
+
+    const r = riskFields(0, sbtc, deployer);
+    expect(r["min-collateral-ratio"]).toBeUint(160);
+    expect(r["liquidation-ratio"]).toBeUint(125);
+    expect(r["liquidation-penalty"]).toBeUint(800);
+    expect(r["debt-floor"]).toBeUint(50);
+    expect(r["debt-ceiling"]).toBeUint(2_000_000);
+    expect(r["enabled"]).toBeBool(false); // preserved
+  });
+
+  it("rejects an unconfigured pair", () => {
+    const { deployer } = accounts();
+    const { vgld } = collats();
+    expect(updatePair(deployer, 0, vgld, RISK).result).toBeErr(Cl.uint(ERR_PAIR_NOT_FOUND));
+  });
+
+  it("rejects invalid ratios", () => {
+    const { deployer } = accounts();
+    const { sbtc } = collats();
+    expect(updatePair(deployer, 0, sbtc, { ...RISK, min: 120, liq: 130 }).result).toBeErr(
+      Cl.uint(ERR_INVALID_RATIO)
+    );
+  });
+});
+
+describe("collateral-matrix: set-pair-enabled", () => {
+  beforeEach(() => {
+    const { deployer } = accounts();
+    registerMarket0(deployer);
+    addPair(deployer, 0, collats().sbtc);
+  });
+
+  it("toggles enabled without disturbing params", () => {
+    const { deployer } = accounts();
+    const { sbtc } = collats();
+    expect(
+      simnet.callPublicFn(MATRIX, "set-pair-enabled", [Cl.uint(0), Cl.principal(sbtc), Cl.bool(false)], deployer).result
+    ).toBeOk(Cl.bool(true));
+    expect(read("is-pair-enabled", [Cl.uint(0), Cl.principal(sbtc)], deployer).result).toBeBool(false);
+    // params intact
+    expect(riskFields(0, sbtc, deployer)["min-collateral-ratio"]).toBeUint(RISK.min);
+
+    simnet.callPublicFn(MATRIX, "set-pair-enabled", [Cl.uint(0), Cl.principal(sbtc), Cl.bool(true)], deployer);
+    expect(read("is-pair-enabled", [Cl.uint(0), Cl.principal(sbtc)], deployer).result).toBeBool(true);
+  });
+
+  it("rejects an unconfigured pair", () => {
+    const { deployer } = accounts();
+    const { vgld } = collats();
+    expect(
+      simnet.callPublicFn(MATRIX, "set-pair-enabled", [Cl.uint(0), Cl.principal(vgld), Cl.bool(true)], deployer).result
+    ).toBeErr(Cl.uint(ERR_PAIR_NOT_FOUND));
+  });
+});
+
+describe("collateral-matrix: governance gating", () => {
+  beforeEach(() => registerMarket0(accounts().deployer));
+
+  it("non-governance cannot add / update / toggle", () => {
+    const { deployer, wallet3 } = accounts();
+    const { sbtc } = collats();
+    addPair(deployer, 0, sbtc); // exists
+
+    expect(addPair(wallet3, 0, collats().vgld).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(updatePair(wallet3, 0, sbtc, RISK).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(
+      simnet.callPublicFn(MATRIX, "set-pair-enabled", [Cl.uint(0), Cl.principal(sbtc), Cl.bool(false)], wallet3).result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+  });
+
+  it("after handoff + lock: pre-lock owner loses access, new governance keeps it", () => {
+    const { deployer, wallet1, wallet2 } = accounts();
+    const { sbtc } = collats();
+    expect(
+      simnet.callPublicFn(MATRIX, "bootstrap-set-governance", [Cl.principal(wallet1)], deployer).result
+    ).toBeOk(Cl.bool(true));
+    expect(simnet.callPublicFn(MATRIX, "lock-bootstrap", [], deployer).result).toBeOk(Cl.bool(true));
+
+    // deployer is owner but bootstrap locked + not governance -> rejected
+    expect(addPair(deployer, 0, sbtc).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(addPair(wallet2, 0, sbtc).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    // governance wallet1 (contract-caller branch) -> ok
+    expect(addPair(wallet1, 0, sbtc).result).toBeOk(Cl.bool(true));
+  });
+
+  it("bootstrap setters reject non-owner; set-gov rejects once locked", () => {
+    const { deployer, wallet2 } = accounts();
+    expect(
+      simnet.callPublicFn(MATRIX, "bootstrap-set-governance", [Cl.principal(wallet2)], wallet2).result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(simnet.callPublicFn(MATRIX, "lock-bootstrap", [], wallet2).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+    expect(simnet.callPublicFn(MATRIX, "lock-bootstrap", [], deployer).result).toBeOk(Cl.bool(true));
+    expect(
+      simnet.callPublicFn(MATRIX, "bootstrap-set-governance", [Cl.principal(wallet2)], deployer).result
+    ).toBeErr(Cl.uint(ERR_BOOTSTRAP_LOCKED));
+  });
+});


### PR DESCRIPTION
Add sse-finance-collateral-matrix-v1 as the collateral<->market risk configuration table where each {market-id, collateral} row defines the five risk parameters (min-collateral-ratio/liquidation-ratio/liquidation-penalty/debt-floor/debt-ceiling) for borrowing that stablecoin against that collateral. Absence of a row means the pair is not borrowable. Structure mirrors collateral-registry-v6