### PR TITLE
feat: add sse-finance-pool-v1 with LP supply/withdraw, bank-run guard  and stability-pool loss/reward distribution 

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -58,6 +58,13 @@ path = "contracts/sse-finance-collateral-matrix-v1.clar"
 epoch = "3.1"
 depends_on = ["sse-finance-market-registry-v1"]
 
+# Liquidity pool: LP supply/withdraw + share accounting, cash management, and the
+# stability-pool product/snapshot loss + collateral-reward distribution engine.
+[contracts.sse-finance-pool-v1]
+path = "contracts/sse-finance-pool-v1.clar"
+epoch = "3.1"
+depends_on = ["sse-finance-sip-010-trait", "sse-finance-market-registry-v1"]
+
 # ── Governance ────────────────────────────────────────────────────────────────
 
 [contracts.sse-governance-v1]

--- a/contracts/sse-finance-pool-v1.clar
+++ b/contracts/sse-finance-pool-v1.clar
@@ -1,0 +1,418 @@
+;; sse-finance-pool-v1.clar
+;;
+;; The SSE Finance liquidity pool: LPs supply a market's borrow-token and receive
+;; shares; borrowers draw that liquidity (via the vault) and repay it; LP yield is
+;; the liquidation discount, distributed in-kind through cumulative-reward-per-token.
+;;
+;; INTEREST-FREE (Liquity-style): there is NO supply index and NO interest. Debt
+;; is flat principal. total-borrows only ever changes on borrow-out / repay-in /
+;; liquidation; it never grows on its own.
+;;
+;; State model (per market-id):
+;;   pool-state: { total-supplied, total-borrows, cash }
+;;     total-supplied = LP principal claim (cash + lent out)
+;;     total-borrows  = principal currently lent out (flat)
+;;     cash           = idle balance available for borrows / withdrawals
+;;
+;; Share + loss accounting reuses stability-pool-v7 verbatim (renamed
+;; stablecoin-id -> market-id): a per-market `product` socialises liquidation
+;; losses across LPs, and a per-{market,asset} `cumulative-reward-per-token`
+;; distributes seized collateral. An LP's effective claim = shares * product /
+;; snapshot-product.
+;;
+;; Withdrawals are capped on-chain at available `cash` (the bank-run guard): an LP
+;; can only pull what the pool actually holds idle, never principal that is lent
+;; out.
+;;
+;; FEE NOTE: borrow-out moves cash and updates total-borrows here. The one-time
+;; borrow-fee split (protocol vs LP share into treasury-accrued) is layered on in
+;; the "Pool: borrow/repay cash management + borrow fee" task.
+
+(use-trait sse-finance-sip-010-trait .sse-finance-sip-010-trait.sse-finance-sip-010-trait)
+
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant SCALE_FACTOR u1000000000000)
+
+;; ============================================
+;; Error Constants
+;; ============================================
+(define-constant ERR_UNAUTHORIZED u600)
+(define-constant ERR_BOOTSTRAP_LOCKED u601)
+(define-constant ERR_MARKET_NOT_FOUND u602)
+(define-constant ERR_TOKEN_MISMATCH u603)
+(define-constant ERR_INSUFFICIENT_BALANCE u604)   ;; LP claim < requested withdraw
+(define-constant ERR_INSUFFICIENT_CASH u605)      ;; bank-run guard: withdraw/borrow > cash
+(define-constant ERR_EMPTY_POOL u606)
+(define-constant ERR_NO_REWARD u607)
+(define-constant ERR_INVALID_AMOUNT u608)
+
+;; ============================================
+;; Governance (mirrors the rest of the SSE Finance package)
+;; ============================================
+(define-data-var governance principal CONTRACT-OWNER)
+(define-data-var bootstrap-locked bool false)
+
+(define-read-only (get-governance) (var-get governance))
+(define-read-only (is-bootstrap-locked) (var-get bootstrap-locked))
+
+(define-public (bootstrap-set-governance (new-gov principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (asserts! (not (var-get bootstrap-locked)) (err ERR_BOOTSTRAP_LOCKED))
+    (var-set governance new-gov)
+    (ok true)
+  )
+)
+
+(define-public (lock-bootstrap)
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (var-set bootstrap-locked true)
+    (ok true)
+  )
+)
+
+(define-private (is-governance-caller)
+  (or
+    (is-eq contract-caller (var-get governance))
+    (and (not (var-get bootstrap-locked)) (is-eq tx-sender CONTRACT-OWNER))
+  )
+)
+
+;; ============================================
+;; Authorized callers (the vault / liquidation engine)
+;; ============================================
+(define-map authorized-callers principal bool)
+
+(define-private (is-authorized-caller)
+  (default-to false (map-get? authorized-callers contract-caller))
+)
+
+(define-read-only (is-caller-authorized (caller principal))
+  (default-to false (map-get? authorized-callers caller))
+)
+
+(define-public (set-authorized-caller (caller principal) (authorized bool))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (map-set authorized-callers caller authorized)
+    (print {event: "authorized-caller-changed", caller: caller, authorized: authorized})
+    (ok true)
+  )
+)
+
+;; ============================================
+;; Data Maps
+;; ============================================
+
+(define-map pool-state
+  {market-id: uint}
+  {total-supplied: uint, total-borrows: uint, cash: uint}
+)
+
+;; Raw LP shares (scaled by product for loss socialisation).
+(define-map lp-shares {lp: principal, market-id: uint} {shares: uint})
+
+;; Liquidation loss + collateral reward (reused from stability-pool-v7).
+(define-map pool-product {market-id: uint} {product: uint})
+(define-map user-product-snapshot {lp: principal, market-id: uint} {product: uint})
+(define-map cumulative-reward-per-token {market-id: uint, asset: principal} {reward-per-token: uint})
+(define-map user-reward-snapshot {lp: principal, market-id: uint, asset: principal} {reward-per-token: uint})
+(define-map pending-collateral-rewards {lp: principal, market-id: uint, asset: principal} {amount: uint})
+
+;; ============================================
+;; Internal helpers
+;; ============================================
+
+(define-private (get-state (market-id uint))
+  (default-to {total-supplied: u0, total-borrows: u0, cash: u0}
+    (map-get? pool-state {market-id: market-id})
+  )
+)
+
+(define-private (get-current-product (market-id uint))
+  (default-to SCALE_FACTOR (get product (map-get? pool-product {market-id: market-id})))
+)
+
+(define-private (get-user-snapshot-product (lp principal) (market-id uint))
+  (default-to SCALE_FACTOR (get product (map-get? user-product-snapshot {lp: lp, market-id: market-id})))
+)
+
+(define-private (get-raw-shares (lp principal) (market-id uint))
+  (default-to u0 (get shares (map-get? lp-shares {lp: lp, market-id: market-id})))
+)
+
+(define-private (get-current-rpt (market-id uint) (asset principal))
+  (default-to u0 (get reward-per-token (map-get? cumulative-reward-per-token {market-id: market-id, asset: asset})))
+)
+
+(define-private (get-user-rpt-snapshot (lp principal) (market-id uint) (asset principal))
+  (default-to u0 (get reward-per-token (map-get? user-reward-snapshot {lp: lp, market-id: market-id, asset: asset})))
+)
+
+(define-private (get-pending-reward (lp principal) (market-id uint) (asset principal))
+  (default-to u0 (get amount (map-get? pending-collateral-rewards {lp: lp, market-id: market-id, asset: asset})))
+)
+
+;; An LP's effective principal claim = shares * product / snapshot-product.
+(define-private (effective-balance (lp principal) (market-id uint))
+  (let (
+      (raw (get-raw-shares lp market-id))
+      (current-product (get-current-product market-id))
+      (snapshot-product (get-user-snapshot-product lp market-id))
+    )
+    (if (is-eq snapshot-product u0) u0 (/ (* raw current-product) snapshot-product))
+  )
+)
+
+;; Borrow-token principal registered for a market, or none if no such market.
+(define-private (market-borrow-token (market-id uint))
+  (contract-call? .sse-finance-market-registry-v1 get-borrow-token market-id)
+)
+
+;; ============================================
+;; Read-only views
+;; ============================================
+
+(define-read-only (get-pool-state (market-id uint)) (get-state market-id))
+(define-read-only (get-total-supplied (market-id uint)) (get total-supplied (get-state market-id)))
+(define-read-only (get-total-borrows (market-id uint)) (get total-borrows (get-state market-id)))
+(define-read-only (get-cash (market-id uint)) (get cash (get-state market-id)))
+;; Available liquidity an LP could withdraw or a borrower could draw right now.
+(define-read-only (get-available-liquidity (market-id uint)) (get cash (get-state market-id)))
+(define-read-only (get-pool-product-value (market-id uint)) (get-current-product market-id))
+(define-read-only (get-shares (lp principal) (market-id uint)) (get-raw-shares lp market-id))
+;; LP's withdrawable principal claim (before the cash cap).
+(define-read-only (balance-of (lp principal) (market-id uint)) (effective-balance lp market-id))
+
+(define-read-only (get-claimable-collateral-reward (lp principal) (market-id uint) (asset principal))
+  (let (
+      (raw (get-raw-shares lp market-id))
+      (current-rpt (get-current-rpt market-id asset))
+      (user-rpt (get-user-rpt-snapshot lp market-id asset))
+      (pending (get-pending-reward lp market-id asset))
+      (new-reward (if (> current-rpt user-rpt) (/ (* raw (- current-rpt user-rpt)) SCALE_FACTOR) u0))
+    )
+    (+ pending new-reward)
+  )
+)
+
+;; ============================================
+;; LP supply / withdraw
+;; ============================================
+
+;; Supply borrow-token to a market; mints shares (denominated in underlying at the
+;; current product) and adds the amount to both total-supplied and cash.
+(define-public (supply (market-id uint) (token <sse-finance-sip-010-trait>) (amount uint))
+  (let (
+      (expected (market-borrow-token market-id))
+      (eff (effective-balance tx-sender market-id))
+      (state (get-state market-id))
+      (current-product (get-current-product market-id))
+    )
+    (asserts! (> amount u0) (err ERR_INVALID_AMOUNT))
+    (asserts! (is-some expected) (err ERR_MARKET_NOT_FOUND))
+    (asserts! (is-eq (contract-of token) (unwrap-panic expected)) (err ERR_TOKEN_MISMATCH))
+
+    (try! (contract-call? token transfer amount tx-sender (as-contract tx-sender) none))
+
+    (map-set lp-shares {lp: tx-sender, market-id: market-id} {shares: (+ eff amount)})
+    (map-set user-product-snapshot {lp: tx-sender, market-id: market-id} {product: current-product})
+    (map-set pool-state {market-id: market-id}
+      (merge state {
+        total-supplied: (+ (get total-supplied state) amount),
+        cash: (+ (get cash state) amount)
+      })
+    )
+    (print {
+      event: "pool-supply",
+      lp: tx-sender,
+      market-id: market-id,
+      amount: amount,
+      shares: (+ eff amount),
+      total-supplied: (+ (get total-supplied state) amount),
+      cash: (+ (get cash state) amount)
+    })
+    (ok (+ eff amount))
+  )
+)
+
+;; Withdraw borrow-token. Capped at the LP's effective claim AND at available cash
+;; (the bank-run guard): an LP can never pull principal that is currently lent out.
+(define-public (withdraw (market-id uint) (token <sse-finance-sip-010-trait>) (amount uint))
+  (let (
+      (expected (market-borrow-token market-id))
+      (eff (effective-balance tx-sender market-id))
+      (state (get-state market-id))
+      (current-product (get-current-product market-id))
+      (lp tx-sender)
+    )
+    (asserts! (> amount u0) (err ERR_INVALID_AMOUNT))
+    (asserts! (is-some expected) (err ERR_MARKET_NOT_FOUND))
+    (asserts! (is-eq (contract-of token) (unwrap-panic expected)) (err ERR_TOKEN_MISMATCH))
+    (asserts! (>= eff amount) (err ERR_INSUFFICIENT_BALANCE))
+    (asserts! (>= (get cash state) amount) (err ERR_INSUFFICIENT_CASH))
+
+    (try! (as-contract (contract-call? token transfer amount tx-sender lp none)))
+
+    (map-set lp-shares {lp: lp, market-id: market-id} {shares: (- eff amount)})
+    (map-set user-product-snapshot {lp: lp, market-id: market-id} {product: current-product})
+    (map-set pool-state {market-id: market-id}
+      (merge state {
+        total-supplied: (- (get total-supplied state) amount),
+        cash: (- (get cash state) amount)
+      })
+    )
+    (print {
+      event: "pool-withdrawal",
+      lp: lp,
+      market-id: market-id,
+      amount: amount,
+      shares: (- eff amount),
+      total-supplied: (- (get total-supplied state) amount),
+      cash: (- (get cash state) amount)
+    })
+    (ok (- eff amount))
+  )
+)
+
+;; ============================================
+;; Cash management (vault-only): borrow-out / repay-in
+;; ============================================
+;; NOTE: the one-time borrow-fee split is added in the next task. Here borrow-out
+;; only moves cash and updates total-borrows.
+
+;; Lend cash out to a recipient. Vault-only. Reverts if amount > cash.
+(define-public (borrow-out (market-id uint) (token <sse-finance-sip-010-trait>) (recipient principal) (amount uint))
+  (let (
+      (expected (market-borrow-token market-id))
+      (state (get-state market-id))
+    )
+    (asserts! (is-authorized-caller) (err ERR_UNAUTHORIZED))
+    (asserts! (> amount u0) (err ERR_INVALID_AMOUNT))
+    (asserts! (is-some expected) (err ERR_MARKET_NOT_FOUND))
+    (asserts! (is-eq (contract-of token) (unwrap-panic expected)) (err ERR_TOKEN_MISMATCH))
+    (asserts! (>= (get cash state) amount) (err ERR_INSUFFICIENT_CASH))
+
+    (try! (as-contract (contract-call? token transfer amount tx-sender recipient none)))
+
+    (map-set pool-state {market-id: market-id}
+      (merge state {
+        total-borrows: (+ (get total-borrows state) amount),
+        cash: (- (get cash state) amount)
+      })
+    )
+    (print {event: "pool-borrow-out", market-id: market-id, recipient: recipient, amount: amount})
+    (ok amount)
+  )
+)
+
+;; Return borrowed cash to the pool. Vault-only. Pulls token from tx-sender (the
+;; repaying borrower) and reduces total-borrows (saturating at 0).
+(define-public (repay-in (market-id uint) (token <sse-finance-sip-010-trait>) (amount uint))
+  (let (
+      (expected (market-borrow-token market-id))
+      (state (get-state market-id))
+    )
+    (asserts! (is-authorized-caller) (err ERR_UNAUTHORIZED))
+    (asserts! (> amount u0) (err ERR_INVALID_AMOUNT))
+    (asserts! (is-some expected) (err ERR_MARKET_NOT_FOUND))
+    (asserts! (is-eq (contract-of token) (unwrap-panic expected)) (err ERR_TOKEN_MISMATCH))
+
+    (try! (contract-call? token transfer amount tx-sender (as-contract tx-sender) none))
+
+    (let ((borrows (get total-borrows state)))
+      (map-set pool-state {market-id: market-id}
+        (merge state {
+          total-borrows: (if (>= borrows amount) (- borrows amount) u0),
+          cash: (+ (get cash state) amount)
+        })
+      )
+    )
+    (print {event: "pool-repay-in", market-id: market-id, amount: amount})
+    (ok amount)
+  )
+)
+
+;; ============================================
+;; Liquidation distribution (authorized: the liquidation engine)
+;; ============================================
+;; Socialise a liquidation: shrink the pool product by the offset, credit seized
+;; collateral to LPs via reward-per-token, and reduce total-supplied/total-borrows
+;; by the offset. cash is unchanged (the offset is the principal that left on
+;; borrow and is now settled in collateral instead of cash).
+(define-public (distribute-liquidation-reward
+    (market-id uint)
+    (asset principal)
+    (debt-offset uint)
+    (collateral-earned uint)
+  )
+  (let (
+      (state (get-state market-id))
+      (supplied (get total-supplied state))
+      (current-product (get-current-product market-id))
+      (current-rpt (get-current-rpt market-id asset))
+    )
+    (asserts! (is-authorized-caller) (err ERR_UNAUTHORIZED))
+    (asserts! (> supplied u0) (err ERR_EMPTY_POOL))
+    (asserts! (>= supplied debt-offset) (err ERR_INSUFFICIENT_BALANCE))
+
+    (map-set pool-product {market-id: market-id}
+      {product: (/ (* current-product (- supplied debt-offset)) supplied)}
+    )
+    (map-set cumulative-reward-per-token {market-id: market-id, asset: asset}
+      {reward-per-token: (+ current-rpt (/ (* collateral-earned SCALE_FACTOR) supplied))}
+    )
+    (let ((borrows (get total-borrows state)))
+      (map-set pool-state {market-id: market-id}
+        (merge state {
+          total-supplied: (- supplied debt-offset),
+          total-borrows: (if (>= borrows debt-offset) (- borrows debt-offset) u0)
+        })
+      )
+    )
+    (print {
+      event: "liquidation-reward-distributed",
+      market-id: market-id,
+      asset: asset,
+      debt-offset: debt-offset,
+      collateral-earned: collateral-earned
+    })
+    (ok true)
+  )
+)
+
+;; ============================================
+;; Claim seized-collateral rewards (LP yield path)
+;; ============================================
+(define-public (claim-collateral-reward
+    (market-id uint)
+    (asset principal)
+    (collateral-token <sse-finance-sip-010-trait>)
+  )
+  (let (
+      (raw (get-raw-shares tx-sender market-id))
+      (current-rpt (get-current-rpt market-id asset))
+      (user-rpt (get-user-rpt-snapshot tx-sender market-id asset))
+      (existing-pending (get-pending-reward tx-sender market-id asset))
+      (new-reward (if (> current-rpt user-rpt) (/ (* raw (- current-rpt user-rpt)) SCALE_FACTOR) u0))
+      (total-claimable (+ existing-pending new-reward))
+      (lp tx-sender)
+    )
+    (asserts! (is-eq (contract-of collateral-token) asset) (err ERR_TOKEN_MISMATCH))
+    (asserts! (> total-claimable u0) (err ERR_NO_REWARD))
+
+    (try! (as-contract (contract-call? collateral-token transfer total-claimable tx-sender lp none)))
+
+    (map-set pending-collateral-rewards {lp: lp, market-id: market-id, asset: asset} {amount: u0})
+    (map-set user-reward-snapshot {lp: lp, market-id: market-id, asset: asset} {reward-per-token: current-rpt})
+    (print {
+      event: "collateral-reward-claimed",
+      lp: lp,
+      market-id: market-id,
+      asset: asset,
+      amount: total-claimable
+    })
+    (ok total-claimable)
+  )
+)

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -58,6 +58,7 @@ genesis:
     - pox-4
     - signers
     - signers-voting
+    - costs-4
 plan:
   batches:
     - id: 0
@@ -67,7 +68,7 @@ plan:
             emulated-sender: SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE
             path: "./.cache/requirements/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.clar"
             clarity-version: 1
-      epoch: "2.0"
+      epoch: "2.1"
     - id: 1
       transactions:
         - emulated-contract-publish:
@@ -198,6 +199,11 @@ plan:
       epoch: "3.1"
     - id: 2
       transactions:
+        - emulated-contract-publish:
+            contract-name: sse-finance-pool-v1
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/sse-finance-pool-v1.clar
+            clarity-version: 3
         - emulated-contract-publish:
             contract-name: sse-governance-v1
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM

--- a/docs/sse-finance-trait-imports.md
+++ b/docs/sse-finance-trait-imports.md
@@ -17,7 +17,7 @@ externally-deployed trait contract.
 |---|---|---|
 | `price-oracle-pegged-usd-v1` | `sse-finance-oracle-trait` | — |
 | `sse-finance-market-registry-v1` | — | — (stores `borrow-token` & `oracle` as **plain principals**, mirroring how `collateral-registry-v6` stores its oracle; trait typing happens at the vault/pool call sites that actually invoke `transfer` / `get-price`) |
-| `sse-finance-pool-v1` *(later)* | — | `sse-finance-sip-010-trait` (borrow token) |
+| `sse-finance-pool-v1` | — | `sse-finance-sip-010-trait` (borrow token on supply/withdraw/borrow-out/repay-in, collateral on claim). Reads the market's borrow-token principal via `contract-call?` to `sse-finance-market-registry-v1`. |
 | `sse-finance-vault-v1` *(later)* | — | `sse-finance-sip-010-trait` (collateral), `sse-finance-oracle-trait` (pricing) |
 | `sse-finance-liquidation-v1` *(later)* | — | `sse-finance-sip-010-trait`, `sse-finance-oracle-trait` |
 

--- a/tests/sse-finance-pool.test.ts
+++ b/tests/sse-finance-pool.test.ts
@@ -1,0 +1,305 @@
+// Full-coverage tests for sse-finance-pool-v1: LP supply/withdraw + share
+// accounting, the on-chain bank-run guard (withdraw capped at cash), cash
+// management (borrow-out / repay-in), and the stability-pool-style liquidation
+// loss + cumulative-reward-per-token collateral-distribution engine.
+//
+// Uses sbtc-token-v4 as the market's borrow-token and vgld-token-v4 as a seized
+// collateral asset (both have an open faucet-mint).
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+const REG = "sse-finance-market-registry-v1";
+const POOL = "sse-finance-pool-v1";
+const BORROW_TOKEN = "sbtc-token-v4";
+const COLLATERAL = "vgld-token-v4";
+
+// Pool error codes (must match the contract).
+const ERR_UNAUTHORIZED = 600;
+const ERR_MARKET_NOT_FOUND = 602;
+const ERR_TOKEN_MISMATCH = 603;
+const ERR_INSUFFICIENT_BALANCE = 604;
+const ERR_INSUFFICIENT_CASH = 605;
+const ERR_NO_REWARD = 607;
+const ERR_INVALID_AMOUNT = 608;
+
+function accounts() {
+  const a = simnet.getAccounts();
+  const deployer = a.get("deployer")!;
+  const lp1 = a.get("wallet_1")!;
+  const lp2 = a.get("wallet_2")!;
+  const vault = a.get("wallet_3")!; // stands in for the vault / liquidation engine
+  const borrower = a.get("wallet_4")!;
+  return { deployer, lp1, lp2, vault, borrower };
+}
+
+function principals() {
+  const { deployer } = accounts();
+  return {
+    borrowToken: `${deployer}.${BORROW_TOKEN}`,
+    collateral: `${deployer}.${COLLATERAL}`,
+    poolAddr: `${deployer}.${POOL}`,
+  };
+}
+
+const borrowTokenCV = () => {
+  const { deployer } = accounts();
+  return Cl.contractPrincipal(deployer, BORROW_TOKEN);
+};
+const collateralCV = () => {
+  const { deployer } = accounts();
+  return Cl.contractPrincipal(deployer, COLLATERAL);
+};
+
+// faucet-mint(amount, recipient). The caller (sender) must be a standard
+// principal, so when minting to the pool contract we pass a wallet as caller.
+function mintBorrow(to: string, amount: number, caller = to) {
+  return simnet.callPublicFn(BORROW_TOKEN, "faucet-mint", [Cl.uint(amount), Cl.principal(to)], caller);
+}
+function mintCollateral(to: string, amount: number, caller = accounts().deployer) {
+  return simnet.callPublicFn(COLLATERAL, "faucet-mint", [Cl.uint(amount), Cl.principal(to)], caller);
+}
+// Token get-balance returns (ok uint); unwrap the response then the uint.
+function tokenBalance(token: string, who: string): number {
+  const res = simnet.callReadOnlyFn(token, "get-balance", [Cl.principal(who)], accounts().deployer)
+    .result as any;
+  return Number(res.value.value as bigint);
+}
+
+// Register market 0 with sbtc as the borrow-token and authorize the "vault".
+function setup() {
+  const { deployer, vault } = accounts();
+  const { borrowToken } = principals();
+  simnet.callPublicFn(
+    REG,
+    "register-market",
+    [
+      Cl.principal(borrowToken),
+      Cl.principal(borrowToken), // oracle (stand-in; pool ignores it)
+      Cl.uint(1_000_000_000),
+      Cl.uint(50),
+      Cl.uint(0),
+      Cl.uint(2000),
+      Cl.uint(0),
+    ],
+    deployer
+  );
+  simnet.callPublicFn(POOL, "set-authorized-caller", [Cl.principal(vault), Cl.bool(true)], deployer);
+}
+
+const supply = (lp: string, amount: number, marketId = 0) =>
+  simnet.callPublicFn(POOL, "supply", [Cl.uint(marketId), borrowTokenCV(), Cl.uint(amount)], lp);
+const withdraw = (lp: string, amount: number, marketId = 0) =>
+  simnet.callPublicFn(POOL, "withdraw", [Cl.uint(marketId), borrowTokenCV(), Cl.uint(amount)], lp);
+const borrowOut = (caller: string, recipient: string, amount: number, marketId = 0) =>
+  simnet.callPublicFn(
+    POOL,
+    "borrow-out",
+    [Cl.uint(marketId), borrowTokenCV(), Cl.principal(recipient), Cl.uint(amount)],
+    caller
+  );
+const repayIn = (caller: string, amount: number, marketId = 0) =>
+  simnet.callPublicFn(POOL, "repay-in", [Cl.uint(marketId), borrowTokenCV(), Cl.uint(amount)], caller);
+const distribute = (caller: string, offset: number, collateralEarned: number, marketId = 0) =>
+  simnet.callPublicFn(
+    POOL,
+    "distribute-liquidation-reward",
+    [Cl.uint(marketId), collateralCV(), Cl.uint(offset), Cl.uint(collateralEarned)],
+    caller
+  );
+const claim = (lp: string, marketId = 0) =>
+  simnet.callPublicFn(POOL, "claim-collateral-reward", [Cl.uint(marketId), collateralCV(), collateralCV()], lp);
+
+const readUint = (fn: string, args: any[]) =>
+  Number((simnet.callReadOnlyFn(POOL, fn, args, accounts().deployer).result as any).value as bigint);
+const state = (marketId = 0) => {
+  const s = (simnet.callReadOnlyFn(POOL, "get-pool-state", [Cl.uint(marketId)], accounts().deployer)
+    .result as any).value;
+  return {
+    supplied: Number(s["total-supplied"].value),
+    borrows: Number(s["total-borrows"].value),
+    cash: Number(s["cash"].value),
+  };
+};
+
+describe("pool: supply + share accounting", () => {
+  beforeEach(setup);
+
+  it("supply mints shares and grows total-supplied + cash together", () => {
+    const { lp1 } = accounts();
+    mintBorrow(lp1, 1000);
+    expect(supply(lp1, 1000).result).toBeOk(Cl.uint(1000));
+
+    expect(state()).toEqual({ supplied: 1000, borrows: 0, cash: 1000 });
+    expect(readUint("get-shares", [Cl.principal(lp1), Cl.uint(0)])).toBe(1000);
+    expect(readUint("balance-of", [Cl.principal(lp1), Cl.uint(0)])).toBe(1000);
+    expect(readUint("get-available-liquidity", [Cl.uint(0)])).toBe(1000);
+  });
+
+  it("two LPs accumulate independent claims", () => {
+    const { lp1, lp2 } = accounts();
+    mintBorrow(lp1, 600);
+    mintBorrow(lp2, 400);
+    supply(lp1, 600);
+    supply(lp2, 400);
+    expect(state()).toEqual({ supplied: 1000, borrows: 0, cash: 1000 });
+    expect(readUint("balance-of", [Cl.principal(lp1), Cl.uint(0)])).toBe(600);
+    expect(readUint("balance-of", [Cl.principal(lp2), Cl.uint(0)])).toBe(400);
+  });
+
+  it("rejects zero amount, unknown market, and token mismatch", () => {
+    const { lp1 } = accounts();
+    mintBorrow(lp1, 1000);
+    expect(supply(lp1, 0).result).toBeErr(Cl.uint(ERR_INVALID_AMOUNT));
+    expect(
+      simnet.callPublicFn(POOL, "supply", [Cl.uint(9), borrowTokenCV(), Cl.uint(10)], lp1).result
+    ).toBeErr(Cl.uint(ERR_MARKET_NOT_FOUND));
+    expect(
+      simnet.callPublicFn(POOL, "supply", [Cl.uint(0), collateralCV(), Cl.uint(10)], lp1).result
+    ).toBeErr(Cl.uint(ERR_TOKEN_MISMATCH));
+  });
+});
+
+describe("pool: withdraw + bank-run guard", () => {
+  beforeEach(setup);
+
+  it("withdraw burns shares for the underlying", () => {
+    const { lp1 } = accounts();
+    mintBorrow(lp1, 1000);
+    supply(lp1, 1000);
+    expect(withdraw(lp1, 400).result).toBeOk(Cl.uint(600));
+    expect(state()).toEqual({ supplied: 600, borrows: 0, cash: 600 });
+    expect(readUint("balance-of", [Cl.principal(lp1), Cl.uint(0)])).toBe(600);
+    // LP got the tokens back
+    expect(tokenBalance(BORROW_TOKEN, lp1)).toBe(400);
+  });
+
+  it("caps withdrawals at available cash once liquidity is lent out (bank-run guard)", () => {
+    const { lp1, vault, borrower } = accounts();
+    mintBorrow(lp1, 1000);
+    supply(lp1, 1000);
+
+    // vault lends 800 out -> cash 200, borrows 800; LP claim still 1000
+    expect(borrowOut(vault, borrower, 800).result).toBeOk(Cl.uint(800));
+    expect(state()).toEqual({ supplied: 1000, borrows: 800, cash: 200 });
+    expect(readUint("balance-of", [Cl.principal(lp1), Cl.uint(0)])).toBe(1000);
+
+    // LP claim (1000) >= 500, but cash (200) < 500 -> guarded
+    expect(withdraw(lp1, 500).result).toBeErr(Cl.uint(ERR_INSUFFICIENT_CASH));
+    // exactly cash is fine
+    expect(withdraw(lp1, 200).result).toBeOk(Cl.uint(800));
+    expect(state()).toEqual({ supplied: 800, borrows: 800, cash: 0 });
+  });
+
+  it("rejects withdrawing more than the LP's effective claim", () => {
+    const { lp1 } = accounts();
+    mintBorrow(lp1, 1000);
+    supply(lp1, 1000);
+    expect(withdraw(lp1, 1001).result).toBeErr(Cl.uint(ERR_INSUFFICIENT_BALANCE));
+  });
+});
+
+describe("pool: cash management (borrow-out / repay-in)", () => {
+  beforeEach(setup);
+
+  it("borrow-out moves cash to the borrower and tracks total-borrows", () => {
+    const { lp1, vault, borrower } = accounts();
+    mintBorrow(lp1, 1000);
+    supply(lp1, 1000);
+    expect(borrowOut(vault, borrower, 700).result).toBeOk(Cl.uint(700));
+    expect(state()).toEqual({ supplied: 1000, borrows: 700, cash: 300 });
+    expect(tokenBalance(BORROW_TOKEN, borrower)).toBe(700);
+  });
+
+  it("borrow-out reverts when amount exceeds cash and rejects non-vault callers", () => {
+    const { lp1, vault, borrower } = accounts();
+    mintBorrow(lp1, 1000);
+    supply(lp1, 1000);
+    expect(borrowOut(vault, borrower, 1001).result).toBeErr(Cl.uint(ERR_INSUFFICIENT_CASH));
+    expect(borrowOut(borrower, borrower, 100).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+  });
+
+  it("repay-in returns cash and reduces total-borrows by exactly the amount", () => {
+    const { lp1, vault, borrower } = accounts();
+    mintBorrow(lp1, 1000);
+    supply(lp1, 1000);
+    borrowOut(vault, borrower, 800); // borrower now holds 800
+    // borrower repays 500 via the vault (tx-sender = borrower)
+    expect(repayIn(borrower /* unauthorized */, 500).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+
+    // authorize the borrower-as-caller path through the vault: vault is authorized,
+    // and repay-in pulls from tx-sender. Simulate by having the vault call while
+    // the borrower holds the funds is not expressible here, so authorize borrower.
+    simnet.callPublicFn(POOL, "set-authorized-caller", [Cl.principal(borrower), Cl.bool(true)], accounts().deployer);
+    expect(repayIn(borrower, 500).result).toBeOk(Cl.uint(500));
+    expect(state()).toEqual({ supplied: 1000, borrows: 300, cash: 700 });
+  });
+});
+
+describe("pool: liquidation distribution + LP collateral claims", () => {
+  beforeEach(setup);
+
+  it("distributes seized collateral pro-rata; LPs claim their share", () => {
+    const { lp1, lp2, vault } = accounts();
+    const { poolAddr } = principals();
+    mintBorrow(lp1, 600);
+    mintBorrow(lp2, 400);
+    supply(lp1, 600);
+    supply(lp2, 400); // supplied 1000
+
+    // fund the pool with the seized collateral it will pay out, then distribute
+    mintCollateral(poolAddr, 100);
+    expect(distribute(vault, 0, 100).result).toBeOk(Cl.bool(true));
+
+    // pro-rata: lp1 60%, lp2 40%
+    expect(
+      readUint("get-claimable-collateral-reward", [Cl.principal(lp1), Cl.uint(0), collateralCV()])
+    ).toBe(60);
+    expect(
+      readUint("get-claimable-collateral-reward", [Cl.principal(lp2), Cl.uint(0), collateralCV()])
+    ).toBe(40);
+
+    expect(claim(lp1).result).toBeOk(Cl.uint(60));
+    expect(claim(lp2).result).toBeOk(Cl.uint(40));
+    // claimed once -> nothing left, second claim reverts
+    expect(claim(lp1).result).toBeErr(Cl.uint(ERR_NO_REWARD));
+    expect(tokenBalance(COLLATERAL, lp1)).toBe(60);
+  });
+
+  it("socialises loss: a full offset zeroes LP principal and converts it to collateral", () => {
+    const { lp1, vault, borrower } = accounts();
+    const { poolAddr } = principals();
+    mintBorrow(lp1, 1000);
+    supply(lp1, 1000);
+    borrowOut(vault, borrower, 1000); // cash 0, borrows 1000, supplied 1000
+
+    // liquidation: full debt offset, 1100 collateral seized (10% penalty)
+    mintCollateral(poolAddr, 1100);
+    expect(distribute(vault, 1000, 1100).result).toBeOk(Cl.bool(true));
+
+    // principal wiped (product -> 0), borrows cleared
+    expect(state()).toEqual({ supplied: 0, borrows: 0, cash: 0 });
+    expect(readUint("balance-of", [Cl.principal(lp1), Cl.uint(0)])).toBe(0);
+    // but the LP can claim the seized collateral
+    expect(claim(lp1).result).toBeOk(Cl.uint(1100));
+  });
+
+  it("distribute rejects non-authorized callers", () => {
+    const { lp1, borrower } = accounts();
+    mintBorrow(lp1, 100);
+    supply(lp1, 100);
+    expect(distribute(borrower, 0, 10).result).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+  });
+});
+
+describe("pool: governance gating", () => {
+  beforeEach(setup);
+
+  it("only governance can set authorized callers", () => {
+    const { borrower } = accounts();
+    expect(
+      simnet.callPublicFn(POOL, "set-authorized-caller", [Cl.principal(borrower), Cl.bool(true)], borrower)
+        .result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+  });
+});


### PR DESCRIPTION
Add sse-finance-pool-v1 as the liquidity pool contract where LPs supply a market's borrow-token and receive shares, borrowers draw that liquidity via the vault, and LP yield is the liquidation discount distributed in-kind through cumulative-reward-per-token. Structure reuses stability-pool-v7 product/snapshot loss socialisation and per-asset reward-per-token collateral distribution