### PR TITLE
feat: implement one-time borrow fee in sse-finance-pool-v1 with netted disbursement and protocol/LP split 

### DIFF
--- a/contracts/sse-finance-pool-v1.clar
+++ b/contracts/sse-finance-pool-v1.clar
@@ -24,14 +24,24 @@
 ;; can only pull what the pool actually holds idle, never principal that is lent
 ;; out.
 ;;
-;; FEE NOTE: borrow-out moves cash and updates total-borrows here. The one-time
-;; borrow-fee split (protocol vs LP share into treasury-accrued) is layered on in
-;; the "Pool: borrow/repay cash management + borrow fee" task.
+;; BORROW FEE -- convention (b) "netted from disbursed" (matches the architecture
+;; flow diagram and the vault): on borrow-out the debt principal is `amount`, the
+;; borrower receives `amount - fee`, and the fee stays in the pool. The fee is
+;; split by the market's borrow-fee-lp-share-bps:
+;;   - protocol-part -> recorded in the registry's treasury-accrued (the pool must
+;;     be an authorized caller in sse-finance-market-registry-v1); the tokens stay
+;;     in pool cash, earmarked, until sweep-fees moves them to the treasury.
+;;   - lp-part -> credited pro-rata to all LP shares by bumping the pool product
+;;     (the mirror of the liquidation-loss shrink), so existing LPs' effective
+;;     balance grows by their share of the fee.
+;; This keeps the invariant cash + total-borrows == total-supplied + treasury-accrued.
+;; repay-in charges no fee (the optional early-repay fee is a fixed-term feature).
 
 (use-trait sse-finance-sip-010-trait .sse-finance-sip-010-trait.sse-finance-sip-010-trait)
 
 (define-constant CONTRACT-OWNER tx-sender)
 (define-constant SCALE_FACTOR u1000000000000)
+(define-constant BPS_DENOM u10000)
 
 ;; ============================================
 ;; Error Constants
@@ -279,13 +289,39 @@
 ;; ============================================
 ;; Cash management (vault-only): borrow-out / repay-in
 ;; ============================================
-;; NOTE: the one-time borrow-fee split is added in the next task. Here borrow-out
-;; only moves cash and updates total-borrows.
 
-;; Lend cash out to a recipient. Vault-only. Reverts if amount > cash.
+;; Quote the borrow fee for an amount on a market (for the vault / UI to show the
+;; net-received amount). borrowed = debt principal; disbursed = what the borrower
+;; actually receives = borrowed - fee.
+(define-read-only (get-borrow-fee-quote (market-id uint) (amount uint))
+  (let (
+      (fc (contract-call? .sse-finance-market-registry-v1 get-fee-config market-id))
+      (fee-bps (match fc cfg (get borrow-fee-bps cfg) u0))
+      (lp-share-bps (match fc cfg (get borrow-fee-lp-share-bps cfg) u0))
+    )
+    (let (
+        (fee (/ (* amount fee-bps) BPS_DENOM))
+      )
+      (let ((lp-part (/ (* fee lp-share-bps) BPS_DENOM)))
+        {
+          borrowed: amount,
+          fee: fee,
+          lp-fee: lp-part,
+          protocol-fee: (- fee lp-part),
+          disbursed: (- amount fee)
+        }
+      )
+    )
+  )
+)
+
+;; Lend cash out to a recipient, charging the one-time borrow fee (netted from the
+;; disbursed amount). Vault-only. `amount` is the debt principal; the recipient
+;; receives `amount - fee`. Reverts if amount > cash.
 (define-public (borrow-out (market-id uint) (token <sse-finance-sip-010-trait>) (recipient principal) (amount uint))
   (let (
       (expected (market-borrow-token market-id))
+      (fc (contract-call? .sse-finance-market-registry-v1 get-fee-config market-id))
       (state (get-state market-id))
     )
     (asserts! (is-authorized-caller) (err ERR_UNAUTHORIZED))
@@ -294,16 +330,62 @@
     (asserts! (is-eq (contract-of token) (unwrap-panic expected)) (err ERR_TOKEN_MISMATCH))
     (asserts! (>= (get cash state) amount) (err ERR_INSUFFICIENT_CASH))
 
-    (try! (as-contract (contract-call? token transfer amount tx-sender recipient none)))
+    (let (
+        (fee-bps (match fc cfg (get borrow-fee-bps cfg) u0))
+        (lp-share-bps (match fc cfg (get borrow-fee-lp-share-bps cfg) u0))
+        (supplied (get total-supplied state))
+        (current-product (get-current-product market-id))
+      )
+      (let (
+          (fee (/ (* amount fee-bps) BPS_DENOM))
+        )
+        (let (
+            (lp-part (/ (* fee lp-share-bps) BPS_DENOM))
+          )
+          (let (
+              (protocol-part (- fee lp-part))
+              (disbursed (- amount fee))
+            )
+            ;; transfer the net amount to the borrower
+            (try! (as-contract (contract-call? token transfer disbursed tx-sender recipient none)))
 
-    (map-set pool-state {market-id: market-id}
-      (merge state {
-        total-borrows: (+ (get total-borrows state) amount),
-        cash: (- (get cash state) amount)
-      })
+            ;; record the protocol fee in the registry's treasury-accrued
+            (if (> protocol-part u0)
+              (try! (contract-call? .sse-finance-market-registry-v1 accrue-fee market-id (contract-of token) protocol-part))
+              u0
+            )
+
+            ;; credit the LP fee share pro-rata via a product bump (gain mirror of
+            ;; the liquidation-loss shrink)
+            (if (and (> lp-part u0) (> supplied u0))
+              (map-set pool-product {market-id: market-id}
+                {product: (/ (* current-product (+ supplied lp-part)) supplied)}
+              )
+              false
+            )
+
+            (map-set pool-state {market-id: market-id}
+              (merge state {
+                total-borrows: (+ (get total-borrows state) amount),
+                cash: (- (get cash state) disbursed),
+                total-supplied: (+ supplied lp-part)
+              })
+            )
+            (print {
+              event: "pool-borrow-out",
+              market-id: market-id,
+              recipient: recipient,
+              borrowed: amount,
+              disbursed: disbursed,
+              fee: fee,
+              protocol-fee: protocol-part,
+              lp-fee: lp-part
+            })
+            (ok disbursed)
+          )
+        )
+      )
     )
-    (print {event: "pool-borrow-out", market-id: market-id, recipient: recipient, amount: amount})
-    (ok amount)
   )
 )
 

--- a/tests/sse-finance-pool.test.ts
+++ b/tests/sse-finance-pool.test.ts
@@ -77,7 +77,7 @@ function setup() {
       Cl.principal(borrowToken),
       Cl.principal(borrowToken), // oracle (stand-in; pool ignores it)
       Cl.uint(1_000_000_000),
-      Cl.uint(50),
+      Cl.uint(0), // borrow-fee-bps: 0 for the pure cash-management tests
       Cl.uint(0),
       Cl.uint(2000),
       Cl.uint(0),
@@ -301,5 +301,90 @@ describe("pool: governance gating", () => {
       simnet.callPublicFn(POOL, "set-authorized-caller", [Cl.principal(borrower), Cl.bool(true)], borrower)
         .result
     ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+  });
+});
+
+describe("pool: one-time borrow fee (netted from disbursed)", () => {
+  // Registry error: accrue-fee rejects a pool that isn't an authorized caller.
+  const REG_ERR_UNAUTHORIZED = 800;
+
+  // Set market 0's fee config and authorize the pool to record fees in the registry.
+  function setFeeAndAuthorizePool(borrowBps: number, lpShareBps: number, authorize = true) {
+    const { deployer } = accounts();
+    const { poolAddr } = principals();
+    simnet.callPublicFn(
+      REG,
+      "set-fee-config",
+      [Cl.uint(0), Cl.uint(borrowBps), Cl.uint(lpShareBps), Cl.uint(2000), Cl.uint(0)],
+      deployer
+    );
+    if (authorize) {
+      simnet.callPublicFn(REG, "set-authorized-caller", [Cl.principal(poolAddr), Cl.bool(true)], deployer);
+    }
+  }
+  const treasuryAccrued = () => {
+    const { deployer } = accounts();
+    const { borrowToken } = principals();
+    return Number(
+      (simnet.callReadOnlyFn(REG, "get-treasury-accrued", [Cl.uint(0), Cl.principal(borrowToken)], deployer)
+        .result as any).value as bigint
+    );
+  };
+  const quote = (amount: number) => {
+    const { deployer } = accounts();
+    const q = (simnet.callReadOnlyFn(POOL, "get-borrow-fee-quote", [Cl.uint(0), Cl.uint(amount)], deployer)
+      .result as any).value;
+    return {
+      borrowed: Number(q["borrowed"].value),
+      fee: Number(q["fee"].value),
+      lpFee: Number(q["lp-fee"].value),
+      protocolFee: Number(q["protocol-fee"].value),
+      disbursed: Number(q["disbursed"].value),
+    };
+  };
+
+  beforeEach(setup);
+
+  it("LP-share 0 (launch): whole fee -> protocol treasury-accrued; borrower nets amount-fee", () => {
+    const { lp1, vault, borrower } = accounts();
+    setFeeAndAuthorizePool(200, 0); // 2% borrow fee, 0 to LPs
+    mintBorrow(lp1, 10_000);
+    supply(lp1, 10_000);
+
+    expect(quote(1000)).toEqual({ borrowed: 1000, fee: 20, lpFee: 0, protocolFee: 20, disbursed: 980 });
+
+    // returns the net disbursed amount
+    expect(borrowOut(vault, borrower, 1000).result).toBeOk(Cl.uint(980));
+    expect(tokenBalance(BORROW_TOKEN, borrower)).toBe(980);
+    expect(state()).toEqual({ supplied: 10_000, borrows: 1000, cash: 9020 });
+    expect(treasuryAccrued()).toBe(20); // whole fee to protocol
+    // LPs unchanged (lp-share 0)
+    expect(readUint("balance-of", [Cl.principal(lp1), Cl.uint(0)])).toBe(10_000);
+  });
+
+  it("LP-share 50%: fee split protocol/LP; LP claim grows by its share", () => {
+    const { lp1, vault, borrower } = accounts();
+    setFeeAndAuthorizePool(200, 5000); // 2% fee, 50% of it to LPs
+    mintBorrow(lp1, 10_000);
+    supply(lp1, 10_000);
+
+    expect(quote(1000)).toEqual({ borrowed: 1000, fee: 20, lpFee: 10, protocolFee: 10, disbursed: 980 });
+
+    expect(borrowOut(vault, borrower, 1000).result).toBeOk(Cl.uint(980));
+    expect(treasuryAccrued()).toBe(10); // protocol half
+    // LP half (10) credited pro-rata: lone LP's claim grows 10000 -> 10010
+    expect(readUint("balance-of", [Cl.principal(lp1), Cl.uint(0)])).toBe(10_010);
+    expect(state()).toEqual({ supplied: 10_010, borrows: 1000, cash: 9020 });
+    // invariant: cash + borrows == supplied + treasury-accrued
+    expect(9020 + 1000).toBe(10_010 + 10);
+  });
+
+  it("borrow-out reverts when the pool is not an authorized fee recorder in the registry", () => {
+    const { lp1, vault, borrower } = accounts();
+    setFeeAndAuthorizePool(200, 0, /* authorize */ false);
+    mintBorrow(lp1, 10_000);
+    supply(lp1, 10_000);
+    // fee>0 triggers registry accrue-fee, which rejects the unauthorized pool
+    expect(borrowOut(vault, borrower, 1000).result).toBeErr(Cl.uint(REG_ERR_UNAUTHORIZED));
   });
 });


### PR DESCRIPTION
Add borrow fee logic to borrow-out using convention (b) "netted from disbursed" where debt principal is `amount`, borrower receives `amount - fee`, and fee stays in pool. Split fee by market's borrow-fee-lp-share-bps: protocol-part recorded in registry's treasury-accrued (requires pool as authorized caller), lp-part credited pro-rata via product bump (gain mirror of liquidation-loss shr