### PR TITLE
feat: add sse-finance-vault-v1 with multi-asset collateral custody, health-checked withdraw, and oracle-validated pricing 

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -65,6 +65,13 @@ path = "contracts/sse-finance-pool-v1.clar"
 epoch = "3.1"
 depends_on = ["sse-finance-sip-010-trait", "sse-finance-market-registry-v1"]
 
+# Borrower vault: multi-asset collateral custody + health-checked withdraw, keyed
+# {owner, market-id}. Prices via per-collateral oracle in the matrix.
+[contracts.sse-finance-vault-v1]
+path = "contracts/sse-finance-vault-v1.clar"
+epoch = "3.1"
+depends_on = ["sse-finance-sip-010-trait", "sse-finance-oracle-trait", "sse-finance-collateral-matrix-v1"]
+
 # ── Governance ────────────────────────────────────────────────────────────────
 
 [contracts.sse-governance-v1]

--- a/contracts/sse-finance-collateral-matrix-v1.clar
+++ b/contracts/sse-finance-collateral-matrix-v1.clar
@@ -86,6 +86,12 @@
 (define-map market-collateral-count {market-id: uint} {count: uint})
 (define-map market-collateral-list {market-id: uint, index: uint} {collateral: principal})
 
+;; The price oracle for each collateral asset, GLOBAL (one oracle per asset, shared
+;; across every market that accepts it -- mirrors how collateral-registry-v6 stores
+;; the oracle on its global per-asset config). The vault validates the caller's
+;; oracle trait against this principal before pricing, and fails closed on mismatch.
+(define-map collateral-oracles {asset: principal} {oracle: principal})
+
 ;; ============================================
 ;; Internal validation
 ;; ============================================
@@ -210,9 +216,25 @@
   )
 )
 
+;; Set (or re-point) the global price oracle for a collateral asset. Governance-
+;; gated. Re-pointing here lets a collateral move to a different oracle principal
+;; (e.g. a live feed) with no redeploy.
+(define-public (set-collateral-oracle (asset principal) (oracle principal))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (map-set collateral-oracles {asset: asset} {oracle: oracle})
+    (print {event: "collateral-oracle-set", asset: asset, oracle: oracle})
+    (ok true)
+  )
+)
+
 ;; ============================================
 ;; Read-Only Functions
 ;; ============================================
+
+(define-read-only (get-collateral-oracle (asset principal))
+  (match (map-get? collateral-oracles {asset: asset}) entry (some (get oracle entry)) none)
+)
 
 ;; The full risk row for a pair (enabled + all five params) in one call. None
 ;; means the pair is not borrowable.

--- a/contracts/sse-finance-vault-v1.clar
+++ b/contracts/sse-finance-vault-v1.clar
@@ -1,0 +1,301 @@
+;; sse-finance-vault-v1.clar
+;;
+;; Borrower-facing vault for SSE Finance: collateral custody + position state,
+;; keyed by {owner, market-id}. Multi-asset positions, enumerable, with a
+;; health-checked withdraw. Shape and health-factor math copied from
+;; multi-asset-vault-engine-v8 (stablecoin-id -> market-id).
+;;
+;; INTEREST-FREE: debt is a flat principal (borrow-principal); it never grows on
+;; its own. This file implements collateral deposit/withdraw only -- borrow &
+;; repay (which move borrow-principal and call the pool) land in the next task,
+;; and liquidate-position in the liquidation task. Until then debt-share is 0, so
+;; the withdraw health check is a no-op and any withdraw within balance succeeds.
+;;
+;; Pricing: each collateral asset has a GLOBAL oracle registered in
+;; sse-finance-collateral-matrix-v1. Every pricing call validates the caller's
+;; oracle trait against that registered principal and FAILS CLOSED on mismatch
+;; (identical to engine v8 price-asset-via). Risk params (min ratio, etc.) for a
+;; {market, collateral} pair come from the same matrix.
+
+(use-trait sse-finance-sip-010-trait .sse-finance-sip-010-trait.sse-finance-sip-010-trait)
+(use-trait sse-finance-oracle-trait .sse-finance-oracle-trait.sse-finance-oracle-trait)
+
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant PRICE-SCALE u100000000)        ;; 8-decimal USD price ($1 = 1e8)
+(define-constant RATIO-SCALE u100)              ;; ratios in whole percent (150 = 150%)
+(define-constant ZERO-DEBT-HEALTH-FACTOR u1000000)
+
+;; ============================================
+;; Error Constants
+;; ============================================
+(define-constant ERR_NO_VAULT u300)
+(define-constant ERR_INSUFFICIENT_COLLATERAL u301)
+(define-constant ERR_UNSAFE_HEALTH_FACTOR u302)
+(define-constant ERR_PAIR_NOT_ENABLED u303)
+(define-constant ERR_NO_COLLATERAL_POSITION u304)
+(define-constant ERR_ASSET_MISMATCH u305)
+(define-constant ERR_ORACLE_MISMATCH u306)
+(define-constant ERR_INVALID_AMOUNT u307)
+(define-constant ERR_UNAUTHORIZED u308)
+(define-constant ERR_BOOTSTRAP_LOCKED u309)
+
+;; ============================================
+;; Governance (for the wiring the borrow/liquidation tasks add later)
+;; ============================================
+(define-data-var governance principal CONTRACT-OWNER)
+(define-data-var bootstrap-locked bool false)
+
+(define-read-only (get-governance) (var-get governance))
+(define-read-only (is-bootstrap-locked) (var-get bootstrap-locked))
+
+(define-public (bootstrap-set-governance (new-gov principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (asserts! (not (var-get bootstrap-locked)) (err ERR_BOOTSTRAP_LOCKED))
+    (var-set governance new-gov)
+    (ok true)
+  )
+)
+
+(define-public (lock-bootstrap)
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (var-set bootstrap-locked true)
+    (ok true)
+  )
+)
+
+;; ============================================
+;; Data Maps
+;; ============================================
+(define-map vaults
+  {owner: principal, market-id: uint}
+  {borrow-principal: uint, created-at: uint}
+)
+
+(define-map vault-collateral
+  {owner: principal, market-id: uint, asset: principal}
+  {amount: uint, debt-share: uint}
+)
+
+(define-map vault-asset-count {owner: principal, market-id: uint} {count: uint})
+(define-map vault-asset-list {owner: principal, market-id: uint, index: uint} {asset: principal})
+
+;; ============================================
+;; Private helpers
+;; ============================================
+
+(define-private (read-asset-count (owner principal) (market-id uint))
+  (default-to u0 (get count (map-get? vault-asset-count {owner: owner, market-id: market-id})))
+)
+
+;; Validate the caller-supplied oracle against the matrix-registered principal for
+;; this collateral, then return its price. Returns u0 on any failure (mismatch,
+;; missing registry entry, or oracle error) so downstream health checks refuse.
+(define-private (price-asset-via (asset principal) (oracle <sse-finance-oracle-trait>))
+  (match (contract-call? .sse-finance-collateral-matrix-v1 get-collateral-oracle asset)
+    registered
+      (if (is-eq (contract-of oracle) registered)
+        (match (contract-call? oracle get-price) price price err-code u0)
+        u0
+      )
+    u0
+  )
+)
+
+;; True iff the caller-supplied oracle matches the registered one (or none is
+;; registered yet). Used to fail closed even when debt is 0.
+(define-private (oracle-matches (asset principal) (oracle <sse-finance-oracle-trait>))
+  (match (contract-call? .sse-finance-collateral-matrix-v1 get-collateral-oracle asset)
+    registered (is-eq (contract-of oracle) registered)
+    true
+  )
+)
+
+(define-private (compute-collateral-value (price uint) (amount uint))
+  (/ (* amount price) PRICE-SCALE)
+)
+
+(define-private (calculate-position-health-factor (collateral-value uint) (debt uint) (min-ratio uint))
+  (if (is-eq debt u0)
+    ZERO-DEBT-HEALTH-FACTOR
+    (/ (* collateral-value u10000) (* debt min-ratio))
+  )
+)
+
+(define-private (get-pair-status (market-id uint) (asset principal))
+  (contract-call? .sse-finance-collateral-matrix-v1 get-pair-status market-id asset)
+)
+
+;; ============================================
+;; Collateral deposit / withdraw
+;; ============================================
+
+;; Deposit a supported collateral into a {owner, market} position. Auto-opens the
+;; vault on first use. The {market, collateral} pair must exist and be enabled in
+;; the matrix.
+(define-public (deposit-collateral
+    (market-id uint)
+    (asset principal)
+    (collateral-token <sse-finance-sip-010-trait>)
+    (amount uint)
+  )
+  (begin
+    (asserts! (> amount u0) (err ERR_INVALID_AMOUNT))
+    (asserts! (is-eq (contract-of collateral-token) asset) (err ERR_ASSET_MISMATCH))
+    (asserts!
+      (match (get-pair-status market-id asset) status (get enabled status) false)
+      (err ERR_PAIR_NOT_ENABLED)
+    )
+
+    ;; auto-open the vault
+    (if (is-none (map-get? vaults {owner: tx-sender, market-id: market-id}))
+      (begin
+        (map-set vaults {owner: tx-sender, market-id: market-id}
+          {borrow-principal: u0, created-at: stacks-block-height})
+        (map-set vault-asset-count {owner: tx-sender, market-id: market-id} {count: u0})
+        true
+      )
+      true
+    )
+
+    (let (
+        (position (default-to {amount: u0, debt-share: u0}
+          (map-get? vault-collateral {owner: tx-sender, market-id: market-id, asset: asset})))
+        (is-new (is-none (map-get? vault-collateral {owner: tx-sender, market-id: market-id, asset: asset})))
+      )
+      (let ((new-amount (+ (get amount position) amount)))
+        (map-set vault-collateral {owner: tx-sender, market-id: market-id, asset: asset}
+          {amount: new-amount, debt-share: (get debt-share position)})
+
+        (if is-new
+          (let ((count (read-asset-count tx-sender market-id)))
+            (map-set vault-asset-list {owner: tx-sender, market-id: market-id, index: count} {asset: asset})
+            (map-set vault-asset-count {owner: tx-sender, market-id: market-id} {count: (+ count u1)})
+          )
+          true
+        )
+
+        (try! (contract-call? collateral-token transfer amount tx-sender (as-contract tx-sender) none))
+        (print {
+          event: "collateral-deposited",
+          owner: tx-sender,
+          market-id: market-id,
+          asset: asset,
+          amount: amount,
+          total: new-amount
+        })
+        (ok new-amount)
+      )
+    )
+  )
+)
+
+;; Withdraw collateral. The oracle is validated against the registered principal
+;; first (fails closed on mismatch). When the position carries debt, the remaining
+;; collateral must keep the position at/above the min ratio.
+(define-public (withdraw-collateral
+    (market-id uint)
+    (asset principal)
+    (collateral-token <sse-finance-sip-010-trait>)
+    (oracle <sse-finance-oracle-trait>)
+    (amount uint)
+  )
+  (begin
+    (asserts! (> amount u0) (err ERR_INVALID_AMOUNT))
+    (asserts! (is-eq (contract-of collateral-token) asset) (err ERR_ASSET_MISMATCH))
+    (asserts! (is-some (map-get? vaults {owner: tx-sender, market-id: market-id})) (err ERR_NO_VAULT))
+    (asserts! (oracle-matches asset oracle) (err ERR_ORACLE_MISMATCH))
+
+    (match (map-get? vault-collateral {owner: tx-sender, market-id: market-id, asset: asset})
+      position
+        (begin
+          (asserts! (>= (get amount position) amount) (err ERR_INSUFFICIENT_COLLATERAL))
+          (let (
+              (new-amount (- (get amount position) amount))
+              (debt-share (get debt-share position))
+              (user tx-sender)
+            )
+            ;; health check only matters once the position carries debt
+            (if (> debt-share u0)
+              (let (
+                  (min-ratio (match (get-pair-status market-id asset) s (get min-collateral-ratio s) u0))
+                  (new-value (compute-collateral-value (price-asset-via asset oracle) new-amount))
+                  (hf (calculate-position-health-factor
+                        (compute-collateral-value (price-asset-via asset oracle) new-amount)
+                        debt-share min-ratio))
+                )
+                (asserts! (>= hf RATIO-SCALE) (err ERR_UNSAFE_HEALTH_FACTOR))
+              )
+              true
+            )
+
+            (map-set vault-collateral {owner: user, market-id: market-id, asset: asset}
+              {amount: new-amount, debt-share: debt-share})
+            (try! (as-contract (contract-call? collateral-token transfer amount tx-sender user none)))
+            (print {
+              event: "collateral-withdrawn",
+              owner: user,
+              market-id: market-id,
+              asset: asset,
+              amount: amount,
+              remaining: new-amount
+            })
+            (ok new-amount)
+          )
+        )
+      (err ERR_NO_COLLATERAL_POSITION)
+    )
+  )
+)
+
+;; ============================================
+;; Read-only views
+;; ============================================
+
+(define-read-only (get-vault (owner principal) (market-id uint))
+  (map-get? vaults {owner: owner, market-id: market-id})
+)
+
+(define-read-only (get-collateral-position (owner principal) (market-id uint) (asset principal))
+  (map-get? vault-collateral {owner: owner, market-id: market-id, asset: asset})
+)
+
+(define-read-only (get-vault-asset-count (owner principal) (market-id uint))
+  (read-asset-count owner market-id)
+)
+
+(define-read-only (get-vault-asset-at-index (owner principal) (market-id uint) (index uint))
+  (map-get? vault-asset-list {owner: owner, market-id: market-id, index: index})
+)
+
+;; Health factor for a position given a price (read-onlys can't call the oracle
+;; trait; off-chain consumers pass the live price). >= RATIO-SCALE (100) is safe.
+(define-read-only (get-position-health-factor (owner principal) (market-id uint) (asset principal) (price uint))
+  (match (map-get? vault-collateral {owner: owner, market-id: market-id, asset: asset})
+    position
+      (calculate-position-health-factor
+        (compute-collateral-value price (get amount position))
+        (get debt-share position)
+        (match (get-pair-status market-id asset) s (get min-collateral-ratio s) RATIO-SCALE))
+    ZERO-DEBT-HEALTH-FACTOR
+  )
+)
+
+(define-read-only (get-position-liquidation-status (owner principal) (market-id uint) (asset principal) (price uint))
+  (match (map-get? vault-collateral {owner: owner, market-id: market-id, asset: asset})
+    position
+      (let (
+          (collateral-value (compute-collateral-value price (get amount position)))
+          (debt-share (get debt-share position))
+          (liq-ratio (match (get-pair-status market-id asset) s (get liquidation-ratio s) RATIO-SCALE))
+          (hf (calculate-position-health-factor
+                (compute-collateral-value price (get amount position))
+                (get debt-share position)
+                (match (get-pair-status market-id asset) s (get liquidation-ratio s) RATIO-SCALE)))
+        )
+        {is-liquidatable: (< hf RATIO-SCALE), health-factor: hf, collateral-value: collateral-value, debt: debt-share}
+      )
+    {is-liquidatable: false, health-factor: ZERO-DEBT-HEALTH-FACTOR, collateral-value: u0, debt: u0}
+  )
+)

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -205,6 +205,11 @@ plan:
             path: contracts/sse-finance-pool-v1.clar
             clarity-version: 3
         - emulated-contract-publish:
+            contract-name: sse-finance-vault-v1
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/sse-finance-vault-v1.clar
+            clarity-version: 3
+        - emulated-contract-publish:
             contract-name: sse-governance-v1
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/sse-governance-v1.clar

--- a/docs/sse-finance-trait-imports.md
+++ b/docs/sse-finance-trait-imports.md
@@ -18,7 +18,7 @@ externally-deployed trait contract.
 | `price-oracle-pegged-usd-v1` | `sse-finance-oracle-trait` | — |
 | `sse-finance-market-registry-v1` | — | — (stores `borrow-token` & `oracle` as **plain principals**, mirroring how `collateral-registry-v6` stores its oracle; trait typing happens at the vault/pool call sites that actually invoke `transfer` / `get-price`) |
 | `sse-finance-pool-v1` | — | `sse-finance-sip-010-trait` (borrow token on supply/withdraw/borrow-out/repay-in, collateral on claim). Reads the market's borrow-token principal via `contract-call?` to `sse-finance-market-registry-v1`. |
-| `sse-finance-vault-v1` *(later)* | — | `sse-finance-sip-010-trait` (collateral), `sse-finance-oracle-trait` (pricing) |
+| `sse-finance-vault-v1` | — | `sse-finance-sip-010-trait` (collateral transfers), `sse-finance-oracle-trait` (collateral pricing). Reads the per-collateral oracle principal + pair risk params via `contract-call?` to `sse-finance-collateral-matrix-v1`. |
 | `sse-finance-liquidation-v1` *(later)* | — | `sse-finance-sip-010-trait`, `sse-finance-oracle-trait` |
 
 Rows marked *(later)* are placeholders for contracts in subsequent tasks; update

--- a/tests/sse-finance-collateral-matrix.test.ts
+++ b/tests/sse-finance-collateral-matrix.test.ts
@@ -283,6 +283,31 @@ describe("collateral-matrix: set-pair-enabled", () => {
   });
 });
 
+describe("collateral-matrix: collateral oracle", () => {
+  it("none when unset; governance sets and re-points it", () => {
+    const { deployer, wallet1, wallet2 } = accounts();
+    const { sbtc } = collats();
+    expect(read("get-collateral-oracle", [Cl.principal(sbtc)], deployer).result).toBeNone();
+
+    expect(
+      simnet.callPublicFn(MATRIX, "set-collateral-oracle", [Cl.principal(sbtc), Cl.principal(wallet1)], deployer).result
+    ).toBeOk(Cl.bool(true));
+    expect(read("get-collateral-oracle", [Cl.principal(sbtc)], deployer).result).toBeSome(Cl.principal(wallet1));
+
+    // re-point
+    simnet.callPublicFn(MATRIX, "set-collateral-oracle", [Cl.principal(sbtc), Cl.principal(wallet2)], deployer);
+    expect(read("get-collateral-oracle", [Cl.principal(sbtc)], deployer).result).toBeSome(Cl.principal(wallet2));
+  });
+
+  it("rejects a non-governance caller", () => {
+    const { wallet1, wallet3 } = accounts();
+    const { sbtc } = collats();
+    expect(
+      simnet.callPublicFn(MATRIX, "set-collateral-oracle", [Cl.principal(sbtc), Cl.principal(wallet1)], wallet3).result
+    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
+  });
+});
+
 describe("collateral-matrix: governance gating", () => {
   beforeEach(() => registerMarket0(accounts().deployer));
 

--- a/tests/sse-finance-vault.test.ts
+++ b/tests/sse-finance-vault.test.ts
@@ -1,0 +1,210 @@
+// Full-coverage tests for sse-finance-vault-v1: collateral deposit/withdraw,
+// keyed {owner, market-id}. Multi-asset positions, enumeration, oracle validated
+// against the matrix-registered principal (fails closed on mismatch), and a
+// health-checked withdraw (no-op while debt is 0 -- the debt>0 rejection path is
+// exercised in the borrow task that wires debt-share).
+//
+// Collateral = sbtc-token-v4 / vgld-token-v4 (faucet-mintable); oracle =
+// price-oracle-pegged-usd-v1 (implements sse-finance-oracle-trait).
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+const REG = "sse-finance-market-registry-v1";
+const MATRIX = "sse-finance-collateral-matrix-v1";
+const VAULT = "sse-finance-vault-v1";
+const ORACLE = "price-oracle-pegged-usd-v1";
+const SBTC = "sbtc-token-v4";
+const VGLD = "vgld-token-v4";
+
+// Vault error codes (must match the contract).
+const ERR_NO_VAULT = 300;
+const ERR_INSUFFICIENT_COLLATERAL = 301;
+const ERR_PAIR_NOT_ENABLED = 303;
+const ERR_NO_COLLATERAL_POSITION = 304;
+const ERR_ASSET_MISMATCH = 305;
+const ERR_ORACLE_MISMATCH = 306;
+const ERR_INVALID_AMOUNT = 307;
+
+function accounts() {
+  const a = simnet.getAccounts();
+  const deployer = a.get("deployer")!;
+  const alice = a.get("wallet_1")!;
+  const bob = a.get("wallet_2")!;
+  return { deployer, alice, bob };
+}
+
+function principals() {
+  const { deployer } = accounts();
+  return {
+    sbtc: `${deployer}.${SBTC}`,
+    vgld: `${deployer}.${VGLD}`,
+    oracle: `${deployer}.${ORACLE}`,
+  };
+}
+const sbtcCV = () => Cl.contractPrincipal(accounts().deployer, SBTC);
+const vgldCV = () => Cl.contractPrincipal(accounts().deployer, VGLD);
+const oracleCV = () => Cl.contractPrincipal(accounts().deployer, ORACLE);
+
+const mint = (token: string, to: string, amount: number) =>
+  simnet.callPublicFn(token, "faucet-mint", [Cl.uint(amount), Cl.principal(to)], to);
+
+// Register market 0, add sBTC + vGLD as collateral with the pegged oracle.
+function setup() {
+  const { deployer } = accounts();
+  const { sbtc, vgld, oracle } = principals();
+  simnet.callPublicFn(
+    REG,
+    "register-market",
+    [Cl.principal(sbtc), Cl.principal(oracle), Cl.uint(1_000_000_000), Cl.uint(0), Cl.uint(0), Cl.uint(2000), Cl.uint(0)],
+    deployer
+  );
+  const addPair = (asset: string) =>
+    simnet.callPublicFn(
+      MATRIX,
+      "add-collateral-to-market",
+      [Cl.uint(0), Cl.principal(asset), Cl.uint(150), Cl.uint(120), Cl.uint(1000), Cl.uint(0), Cl.uint(1_000_000_000)],
+      deployer
+    );
+  addPair(sbtc);
+  addPair(vgld);
+  simnet.callPublicFn(MATRIX, "set-collateral-oracle", [Cl.principal(sbtc), Cl.principal(oracle)], deployer);
+  simnet.callPublicFn(MATRIX, "set-collateral-oracle", [Cl.principal(vgld), Cl.principal(oracle)], deployer);
+}
+
+const deposit = (who: string, asset: any, token: string, amount: number, marketId = 0) =>
+  simnet.callPublicFn(VAULT, "deposit-collateral", [Cl.uint(marketId), asset, Cl.contractPrincipal(accounts().deployer, token), Cl.uint(amount)], who);
+const withdraw = (who: string, asset: any, token: string, oracle: any, amount: number, marketId = 0) =>
+  simnet.callPublicFn(VAULT, "withdraw-collateral", [Cl.uint(marketId), asset, Cl.contractPrincipal(accounts().deployer, token), oracle, Cl.uint(amount)], who);
+
+const positionAmount = (who: string, asset: any, marketId = 0): number | null => {
+  const res = simnet.callReadOnlyFn(VAULT, "get-collateral-position", [Cl.principal(who), Cl.uint(marketId), asset], accounts().deployer).result as any;
+  if (res.type === "none") return null;
+  return Number(res.value.value["amount"].value as bigint);
+};
+const assetCount = (who: string, marketId = 0): number =>
+  Number((simnet.callReadOnlyFn(VAULT, "get-vault-asset-count", [Cl.principal(who), Cl.uint(marketId)], accounts().deployer).result as any).value as bigint);
+const tokenBalance = (token: string, who: string): number =>
+  Number(((simnet.callReadOnlyFn(token, "get-balance", [Cl.principal(who)], accounts().deployer).result as any).value).value as bigint);
+
+describe("vault: deposit", () => {
+  beforeEach(setup);
+
+  it("deposits collateral, auto-opens the vault, tracks the position", () => {
+    const { alice } = accounts();
+    mint(SBTC, alice, 1000);
+    expect(deposit(alice, sbtcCV(), SBTC, 1000).result).toBeOk(Cl.uint(1000));
+
+    expect(simnet.callReadOnlyFn(VAULT, "get-vault", [Cl.principal(alice), Cl.uint(0)], alice).result).not.toBeNone();
+    expect(positionAmount(alice, sbtcCV())).toBe(1000);
+    expect(assetCount(alice)).toBe(1);
+    expect(tokenBalance(SBTC, `${accounts().deployer}.${VAULT}`)).toBe(1000);
+  });
+
+  it("accumulates on repeat deposits of the same asset without double-enumerating", () => {
+    const { alice } = accounts();
+    mint(SBTC, alice, 1500);
+    deposit(alice, sbtcCV(), SBTC, 1000);
+    expect(deposit(alice, sbtcCV(), SBTC, 500).result).toBeOk(Cl.uint(1500));
+    expect(positionAmount(alice, sbtcCV())).toBe(1500);
+    expect(assetCount(alice)).toBe(1);
+  });
+
+  it("supports multi-asset positions, enumerable", () => {
+    const { alice } = accounts();
+    const { sbtc, vgld } = principals();
+    mint(SBTC, alice, 1000);
+    mint(VGLD, alice, 2000);
+    deposit(alice, sbtcCV(), SBTC, 1000);
+    deposit(alice, vgldCV(), VGLD, 2000);
+    expect(assetCount(alice)).toBe(2);
+    const at0 = simnet.callReadOnlyFn(VAULT, "get-vault-asset-at-index", [Cl.principal(alice), Cl.uint(0), Cl.uint(0)], alice).result as any;
+    const at1 = simnet.callReadOnlyFn(VAULT, "get-vault-asset-at-index", [Cl.principal(alice), Cl.uint(0), Cl.uint(1)], alice).result as any;
+    expect(at0.value.value["asset"]).toBePrincipal(sbtc);
+    expect(at1.value.value["asset"]).toBePrincipal(vgld);
+  });
+
+  it("rejects zero amount, asset/token mismatch, and a non-enabled pair", () => {
+    const { alice } = accounts();
+    mint(SBTC, alice, 1000);
+    expect(deposit(alice, sbtcCV(), SBTC, 0).result).toBeErr(Cl.uint(ERR_INVALID_AMOUNT));
+    // asset arg = vgld but token = sbtc
+    expect(deposit(alice, vgldCV(), SBTC, 100).result).toBeErr(Cl.uint(ERR_ASSET_MISMATCH));
+    // disable the sbtc pair -> deposit refused
+    simnet.callPublicFn(MATRIX, "set-pair-enabled", [Cl.uint(0), sbtcCV(), Cl.bool(false)], accounts().deployer);
+    expect(deposit(alice, sbtcCV(), SBTC, 100).result).toBeErr(Cl.uint(ERR_PAIR_NOT_ENABLED));
+  });
+
+  it("rejects a collateral with no matrix row (pair not borrowable)", () => {
+    const { alice } = accounts();
+    // market 1 has no pairs configured
+    simnet.callPublicFn(
+      REG, "register-market",
+      [Cl.principal(principals().sbtc), Cl.principal(principals().oracle), Cl.uint(1), Cl.uint(0), Cl.uint(0), Cl.uint(0), Cl.uint(0)],
+      accounts().deployer
+    );
+    mint(SBTC, alice, 100);
+    expect(deposit(alice, sbtcCV(), SBTC, 100, 1).result).toBeErr(Cl.uint(ERR_PAIR_NOT_ENABLED));
+  });
+});
+
+describe("vault: withdraw (debt-free)", () => {
+  beforeEach(() => {
+    setup();
+    const { alice } = accounts();
+    mint(SBTC, alice, 1000);
+    deposit(alice, sbtcCV(), SBTC, 1000);
+  });
+
+  it("withdraws within balance and returns the tokens", () => {
+    const { alice } = accounts();
+    expect(withdraw(alice, sbtcCV(), SBTC, oracleCV(), 400).result).toBeOk(Cl.uint(600));
+    expect(positionAmount(alice, sbtcCV())).toBe(600);
+    expect(tokenBalance(SBTC, alice)).toBe(400);
+  });
+
+  it("rejects withdrawing more than the deposited amount", () => {
+    const { alice } = accounts();
+    expect(withdraw(alice, sbtcCV(), SBTC, oracleCV(), 1001).result).toBeErr(Cl.uint(ERR_INSUFFICIENT_COLLATERAL));
+  });
+
+  it("fails closed when the oracle does not match the registered principal", () => {
+    const { alice, deployer } = accounts();
+    const { sbtc, vgld } = principals();
+    // re-point sbtc's registered oracle to some other principal
+    simnet.callPublicFn(MATRIX, "set-collateral-oracle", [Cl.principal(sbtc), Cl.principal(vgld)], deployer);
+    // caller still passes the pegged oracle -> mismatch
+    expect(withdraw(alice, sbtcCV(), SBTC, oracleCV(), 100).result).toBeErr(Cl.uint(ERR_ORACLE_MISMATCH));
+    // restore -> succeeds
+    simnet.callPublicFn(MATRIX, "set-collateral-oracle", [Cl.principal(sbtc), Cl.principal(principals().oracle)], deployer);
+    expect(withdraw(alice, sbtcCV(), SBTC, oracleCV(), 100).result).toBeOk(Cl.uint(900));
+  });
+
+  it("rejects withdraw with no vault / no position", () => {
+    const { bob } = accounts();
+    // bob never deposited -> no vault
+    expect(withdraw(bob, sbtcCV(), SBTC, oracleCV(), 1).result).toBeErr(Cl.uint(ERR_NO_VAULT));
+    // alice has a vault but no vGLD position
+    const { alice } = accounts();
+    expect(withdraw(alice, vgldCV(), VGLD, oracleCV(), 1).result).toBeErr(Cl.uint(ERR_NO_COLLATERAL_POSITION));
+  });
+});
+
+describe("vault: read-only health views", () => {
+  beforeEach(() => {
+    setup();
+    const { alice } = accounts();
+    mint(SBTC, alice, 1000);
+    deposit(alice, sbtcCV(), SBTC, 1000);
+  });
+
+  it("zero-debt position reports the zero-debt health factor and not liquidatable", () => {
+    const { alice } = accounts();
+    const USD_1 = 100_000_000;
+    expect(
+      simnet.callReadOnlyFn(VAULT, "get-position-health-factor", [Cl.principal(alice), Cl.uint(0), sbtcCV(), Cl.uint(USD_1)], alice).result
+    ).toBeUint(1_000_000);
+    const status = simnet.callReadOnlyFn(VAULT, "get-position-liquidation-status", [Cl.principal(alice), Cl.uint(0), sbtcCV(), Cl.uint(USD_1)], alice).result as any;
+    expect(status.value["is-liquidatable"].type).toBe("false");
+  });
+});


### PR DESCRIPTION

Add sse-finance-vault-v1 as the borrower-facing collateral custody contract where positions are keyed by {owner, market-id} and support multiple collateral assets per vault. Structure mirrors multi-asset-vault-engine-v8 with enumerable asset lists (sequential index doubles as enumeration), per-asset position tracking (amount + debt-share), and health-factor math