### PR TITLE
feat: add sse-finance-liquidation-v1 with permissionless trigger, pro-rata LP distribution, and protocol penalty split

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -72,6 +72,13 @@ path = "contracts/sse-finance-vault-v1.clar"
 epoch = "3.1"
 depends_on = ["sse-finance-sip-010-trait", "sse-finance-oracle-trait", "sse-finance-collateral-matrix-v1", "sse-finance-market-registry-v1", "sse-finance-pool-v1"]
 
+# Liquidation engine (Mechanism A): permissionless trigger, pro-rata in-kind LP
+# distribution, protocol penalty cut to treasury-accrued.
+[contracts.sse-finance-liquidation-v1]
+path = "contracts/sse-finance-liquidation-v1.clar"
+epoch = "3.1"
+depends_on = ["sse-finance-sip-010-trait", "sse-finance-oracle-trait", "sse-finance-collateral-matrix-v1", "sse-finance-market-registry-v1", "sse-finance-pool-v1", "sse-finance-vault-v1"]
+
 # ── Governance ────────────────────────────────────────────────────────────────
 
 [contracts.sse-governance-v1]

--- a/contracts/sse-finance-liquidation-v1.clar
+++ b/contracts/sse-finance-liquidation-v1.clar
@@ -1,0 +1,239 @@
+;; sse-finance-liquidation-v1.clar
+;;
+;; Liquidation engine for SSE Finance -- Mechanism A (pro-rata in-kind, the launch
+;; default). A permissionless `liquidate` trigger:
+;;   1. validates the oracle and reads the position's health against the pair's
+;;      liquidation-ratio; reverts if the position is healthy;
+;;   2. computes debt-to-offset = min(positionDebt, pool capacity) and
+;;      collateral-to-seize = base + penalty (capped at the available collateral);
+;;   3. settles via the vault's liquidate-position (which moves the seized
+;;      collateral to the pool);
+;;   4. splits the penalty: protocol-liq-share-bps of it is earmarked to the
+;;      registry treasury-accrued, the remainder is distributed to LPs through the
+;;      pool's cumulative-reward-per-token.
+;;
+;; The discount (penalty) is the LP's whole return in the interest-free model.
+;; Wiring (deploy time): this engine must be the vault's liquidator, and an
+;; authorized caller in both the pool (distribute) and the registry (accrue-fee).
+
+(use-trait sse-finance-sip-010-trait .sse-finance-sip-010-trait.sse-finance-sip-010-trait)
+(use-trait sse-finance-oracle-trait .sse-finance-oracle-trait.sse-finance-oracle-trait)
+
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant PRICE-SCALE u100000000)
+(define-constant RATIO-SCALE u100)
+(define-constant BPS-DENOM u10000)
+
+;; ============================================
+;; Error Constants
+;; ============================================
+(define-constant ERR_UNAUTHORIZED u400)
+(define-constant ERR_BOOTSTRAP_LOCKED u401)
+(define-constant ERR_POSITION_HEALTHY u402)
+(define-constant ERR_NO_POSITION u403)
+(define-constant ERR_ORACLE_MISMATCH u404)
+(define-constant ERR_PAIR_NOT_FOUND u405)
+(define-constant ERR_EMPTY_POOL u406)
+
+;; ============================================
+;; Governance
+;; ============================================
+(define-data-var governance principal CONTRACT-OWNER)
+(define-data-var bootstrap-locked bool false)
+
+(define-read-only (get-governance) (var-get governance))
+(define-read-only (is-bootstrap-locked) (var-get bootstrap-locked))
+
+(define-public (bootstrap-set-governance (new-gov principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (asserts! (not (var-get bootstrap-locked)) (err ERR_BOOTSTRAP_LOCKED))
+    (var-set governance new-gov)
+    (ok true)
+  )
+)
+
+(define-public (lock-bootstrap)
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
+    (var-set bootstrap-locked true)
+    (ok true)
+  )
+)
+
+(define-private (is-governance-caller)
+  (or
+    (is-eq contract-caller (var-get governance))
+    (and (not (var-get bootstrap-locked)) (is-eq tx-sender CONTRACT-OWNER))
+  )
+)
+
+;; Optional fixed reward for whoever triggers a liquidation (config only; payout
+;; wiring is left to an off-chain incentive or a future funded path).
+(define-data-var trigger-reward uint u0)
+(define-read-only (get-trigger-reward) (var-get trigger-reward))
+(define-public (set-trigger-reward (amount uint))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (var-set trigger-reward amount)
+    (ok true)
+  )
+)
+
+;; ============================================
+;; Liquidation records
+;; ============================================
+(define-data-var liquidation-count uint u0)
+(define-map liquidations
+  {id: uint}
+  {
+    owner: principal,
+    market-id: uint,
+    asset: principal,
+    debt-written-off: uint,
+    collateral-seized: uint,
+    protocol-cut: uint,
+    block: uint
+  }
+)
+(define-read-only (get-liquidation-count) (var-get liquidation-count))
+(define-read-only (get-liquidation (id uint)) (map-get? liquidations {id: id}))
+
+;; ============================================
+;; Helpers
+;; ============================================
+
+(define-private (min-uint (a uint) (b uint)) (if (<= a b) a b))
+
+(define-private (oracle-matches (asset principal) (oracle <sse-finance-oracle-trait>))
+  (match (contract-call? .sse-finance-collateral-matrix-v1 get-collateral-oracle asset)
+    registered (is-eq (contract-of oracle) registered)
+    false
+  )
+)
+
+(define-private (price-asset-via (asset principal) (oracle <sse-finance-oracle-trait>))
+  (match (contract-call? .sse-finance-collateral-matrix-v1 get-collateral-oracle asset)
+    registered
+      (if (is-eq (contract-of oracle) registered)
+        (match (contract-call? oracle get-price) price price err-code u0)
+        u0
+      )
+    u0
+  )
+)
+
+(define-private (health-factor (collateral-value uint) (debt uint) (ratio uint))
+  (if (is-eq debt u0) u1000000 (/ (* collateral-value u10000) (* debt ratio)))
+)
+
+(define-private (protocol-liq-share (market-id uint))
+  (match (contract-call? .sse-finance-market-registry-v1 get-fee-config market-id)
+    cfg (get protocol-liq-share-bps cfg)
+    u0
+  )
+)
+
+;; ============================================
+;; Liquidate (permissionless)
+;; ============================================
+(define-public (liquidate
+    (owner principal)
+    (market-id uint)
+    (asset principal)
+    (collateral-token <sse-finance-sip-010-trait>)
+    (oracle <sse-finance-oracle-trait>)
+  )
+  (begin
+    (asserts! (oracle-matches asset oracle) (err ERR_ORACLE_MISMATCH))
+    (match (contract-call? .sse-finance-vault-v1 get-collateral-position owner market-id asset)
+      position
+        (match (contract-call? .sse-finance-collateral-matrix-v1 get-collateral-risk market-id asset)
+          risk
+            (let (
+                (price (price-asset-via asset oracle))
+                (coll-amount (get amount position))
+                (debt (get debt-share position))
+                (liq-ratio (get liquidation-ratio risk))
+                (penalty-bps (get liquidation-penalty risk))
+                (collateral-value (/ (* coll-amount price) PRICE-SCALE))
+                (capacity (contract-call? .sse-finance-pool-v1 get-total-supplied market-id))
+              )
+              (asserts! (> debt u0) (err ERR_NO_POSITION))
+              (asserts! (< (health-factor collateral-value debt liq-ratio) RATIO-SCALE) (err ERR_POSITION_HEALTHY))
+              (asserts! (> capacity u0) (err ERR_EMPTY_POOL))
+
+              (let (
+                  (debt-to-offset (min-uint debt capacity))
+                )
+                (let (
+                    (base-collateral (/ (* debt-to-offset PRICE-SCALE) price))
+                  )
+                  (let (
+                      (penalty-collateral (/ (* base-collateral penalty-bps) BPS-DENOM))
+                    )
+                    (let (
+                        (collateral-to-seize (min-uint (+ base-collateral penalty-collateral) coll-amount))
+                        (protocol-cut-raw (/ (* penalty-collateral (protocol-liq-share market-id)) BPS-DENOM))
+                      )
+                      (let (
+                          (protocol-cut (min-uint protocol-cut-raw collateral-to-seize))
+                        )
+                        (let (
+                            (lp-collateral (- collateral-to-seize protocol-cut))
+                            (id (var-get liquidation-count))
+                          )
+                          ;; 1. settle on the vault (moves seized collateral to the pool)
+                          (try! (contract-call? .sse-finance-vault-v1 liquidate-position
+                                  owner market-id asset collateral-token debt-to-offset collateral-to-seize))
+                          ;; 2. distribute the LP share + socialise the offset loss
+                          (try! (contract-call? .sse-finance-pool-v1 distribute-liquidation-reward
+                                  market-id asset debt-to-offset lp-collateral))
+                          ;; 3. earmark the protocol penalty cut
+                          (if (> protocol-cut u0)
+                            (try! (contract-call? .sse-finance-market-registry-v1 accrue-fee market-id asset protocol-cut))
+                            u0
+                          )
+
+                          (map-set liquidations {id: id}
+                            {
+                              owner: owner,
+                              market-id: market-id,
+                              asset: asset,
+                              debt-written-off: debt-to-offset,
+                              collateral-seized: collateral-to-seize,
+                              protocol-cut: protocol-cut,
+                              block: stacks-block-height
+                            })
+                          (var-set liquidation-count (+ id u1))
+                          (print {
+                            event: "liquidation",
+                            id: id,
+                            owner: owner,
+                            market-id: market-id,
+                            asset: asset,
+                            debt-written-off: debt-to-offset,
+                            collateral-seized: collateral-to-seize,
+                            protocol-cut: protocol-cut,
+                            lp-collateral: lp-collateral,
+                            triggered-by: tx-sender
+                          })
+                          (ok {
+                            debt-written-off: debt-to-offset,
+                            collateral-seized: collateral-to-seize,
+                            protocol-cut: protocol-cut,
+                            lp-collateral: lp-collateral
+                          })
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          (err ERR_PAIR_NOT_FOUND)
+        )
+      (err ERR_NO_POSITION)
+    )
+  )
+)

--- a/contracts/sse-finance-vault-v1.clar
+++ b/contracts/sse-finance-vault-v1.clar
@@ -41,6 +41,7 @@
 (define-constant ERR_INSUFFICIENT_DEBT u310)
 (define-constant ERR_BELOW_DEBT_FLOOR u311)
 (define-constant ERR_BORROW_CAP u312)
+(define-constant ERR_NOT_LIQUIDATOR u313)
 
 ;; ============================================
 ;; Governance (for the wiring the borrow/liquidation tasks add later)
@@ -64,6 +65,28 @@
   (begin
     (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR_UNAUTHORIZED))
     (var-set bootstrap-locked true)
+    (ok true)
+  )
+)
+
+(define-private (is-governance-caller)
+  (or
+    (is-eq contract-caller (var-get governance))
+    (and (not (var-get bootstrap-locked)) (is-eq tx-sender CONTRACT-OWNER))
+  )
+)
+
+;; The single liquidation engine permitted to call liquidate-position. Set by
+;; governance at deploy (a principal, not a hardcoded contract literal, so the
+;; vault carries no circular dependency on the liquidation contract).
+(define-data-var liquidator (optional principal) none)
+(define-read-only (get-liquidator) (var-get liquidator))
+
+(define-public (set-liquidator (engine principal))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (var-set liquidator (some engine))
+    (print {event: "liquidator-set", engine: engine})
     (ok true)
   )
 )
@@ -364,6 +387,60 @@
                   )
                 )
               (err ERR_PAIR_NOT_ENABLED)
+            )
+          (err ERR_NO_COLLATERAL_POSITION)
+        )
+      (err ERR_NO_VAULT)
+    )
+  )
+)
+
+;; ============================================
+;; Liquidation settlement (liquidator-only)
+;; ============================================
+
+;; Settle a liquidation: reduce the position's collateral and debt by the seized /
+;; offset amounts and move the seized collateral to the pool (which distributes it
+;; to LPs and earmarks the protocol penalty cut). Callable only by the configured
+;; liquidation engine. The engine computes the amounts; this just applies them.
+(define-public (liquidate-position
+    (owner principal)
+    (market-id uint)
+    (asset principal)
+    (collateral-token <sse-finance-sip-010-trait>)
+    (debt-to-offset uint)
+    (collateral-to-seize uint)
+  )
+  (begin
+    (asserts! (is-eq (some contract-caller) (var-get liquidator)) (err ERR_NOT_LIQUIDATOR))
+    (asserts! (is-eq (contract-of collateral-token) asset) (err ERR_ASSET_MISMATCH))
+    (match (map-get? vaults {owner: owner, market-id: market-id})
+      vault
+        (match (map-get? vault-collateral {owner: owner, market-id: market-id, asset: asset})
+          position
+            (begin
+              (asserts! (>= (get amount position) collateral-to-seize) (err ERR_INSUFFICIENT_COLLATERAL))
+              (asserts! (>= (get debt-share position) debt-to-offset) (err ERR_INSUFFICIENT_DEBT))
+
+              (map-set vault-collateral {owner: owner, market-id: market-id, asset: asset}
+                {amount: (- (get amount position) collateral-to-seize),
+                 debt-share: (- (get debt-share position) debt-to-offset)})
+              (map-set vaults {owner: owner, market-id: market-id}
+                (merge vault {borrow-principal: (- (get borrow-principal vault) debt-to-offset)}))
+
+              ;; move the seized collateral to the pool for LP distribution +
+              ;; protocol-cut earmarking
+              (try! (as-contract (contract-call? collateral-token transfer collateral-to-seize tx-sender .sse-finance-pool-v1 none)))
+
+              (print {
+                event: "position-liquidated",
+                owner: owner,
+                market-id: market-id,
+                asset: asset,
+                debt-offset: debt-to-offset,
+                collateral-seized: collateral-to-seize
+              })
+              (ok true)
             )
           (err ERR_NO_COLLATERAL_POSITION)
         )

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -210,6 +210,11 @@ plan:
             path: contracts/sse-finance-vault-v1.clar
             clarity-version: 3
         - emulated-contract-publish:
+            contract-name: sse-finance-liquidation-v1
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/sse-finance-liquidation-v1.clar
+            clarity-version: 3
+        - emulated-contract-publish:
             contract-name: sse-governance-v1
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/sse-governance-v1.clar

--- a/docs/sse-finance-trait-imports.md
+++ b/docs/sse-finance-trait-imports.md
@@ -19,7 +19,7 @@ externally-deployed trait contract.
 | `sse-finance-market-registry-v1` | — | — (stores `borrow-token` & `oracle` as **plain principals**, mirroring how `collateral-registry-v6` stores its oracle; trait typing happens at the vault/pool call sites that actually invoke `transfer` / `get-price`) |
 | `sse-finance-pool-v1` | — | `sse-finance-sip-010-trait` (borrow token on supply/withdraw/borrow-out/repay-in, collateral on claim). Reads the market's borrow-token principal via `contract-call?` to `sse-finance-market-registry-v1`. |
 | `sse-finance-vault-v1` | — | `sse-finance-sip-010-trait` (collateral transfers), `sse-finance-oracle-trait` (collateral pricing). Reads the per-collateral oracle principal + pair risk params via `contract-call?` to `sse-finance-collateral-matrix-v1`. |
-| `sse-finance-liquidation-v1` *(later)* | — | `sse-finance-sip-010-trait`, `sse-finance-oracle-trait` |
+| `sse-finance-liquidation-v1` | — | `sse-finance-sip-010-trait` (collateral, passed to the vault), `sse-finance-oracle-trait` (collateral pricing). Calls vault `liquidate-position`, pool `distribute-liquidation-reward`, registry `accrue-fee`; reads risk/oracle from the matrix and `protocol-liq-share-bps` from the registry. |
 
 Rows marked *(later)* are placeholders for contracts in subsequent tasks; update
 this table as each lands.

--- a/tests/sse-finance-liquidation.test.ts
+++ b/tests/sse-finance-liquidation.test.ts
@@ -1,0 +1,174 @@
+// Full-coverage tests for sse-finance-liquidation-v1 (Mechanism A).
+//
+// Full wiring + an unhealthy position created by dropping the (pegged) collateral
+// oracle below $1 (deviation band widened to allow it). Verifies: healthy ->
+// revert; permissionless trigger; debt + collateral drop by the settled amounts;
+// penalty split (protocol cut -> treasury-accrued, remainder -> LPs); LP can claim
+// the seized collateral; oracle mismatch + no-position reverts.
+//
+// borrow-token = vgld-token-v4, collateral = sbtc-token-v4, oracle = pegged USD.
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+const REG = "sse-finance-market-registry-v1";
+const MATRIX = "sse-finance-collateral-matrix-v1";
+const POOL = "sse-finance-pool-v1";
+const VAULT = "sse-finance-vault-v1";
+const LIQ = "sse-finance-liquidation-v1";
+const ORACLE = "price-oracle-pegged-usd-v1";
+const BORROW = "vgld-token-v4";
+const COLL = "sbtc-token-v4";
+
+const ERR_POSITION_HEALTHY = 402;
+const ERR_NO_POSITION = 403;
+const ERR_ORACLE_MISMATCH = 404;
+
+function accounts() {
+  const a = simnet.getAccounts();
+  const deployer = a.get("deployer")!;
+  const lp = a.get("wallet_1")!;
+  const alice = a.get("wallet_2")!; // borrower
+  const keeper = a.get("wallet_3")!; // permissionless liquidation trigger
+  return { deployer, lp, alice, keeper };
+}
+function principals() {
+  const { deployer } = accounts();
+  return {
+    borrow: `${deployer}.${BORROW}`,
+    coll: `${deployer}.${COLL}`,
+    oracle: `${deployer}.${ORACLE}`,
+    pool: `${deployer}.${POOL}`,
+    vault: `${deployer}.${VAULT}`,
+    liq: `${deployer}.${LIQ}`,
+  };
+}
+const borrowCV = () => Cl.contractPrincipal(accounts().deployer, BORROW);
+const collCV = () => Cl.contractPrincipal(accounts().deployer, COLL);
+const oracleCV = () => Cl.contractPrincipal(accounts().deployer, ORACLE);
+const mint = (token: string, to: string, amount: number) =>
+  simnet.callPublicFn(token, "faucet-mint", [Cl.uint(amount), Cl.principal(to)], to);
+
+function wire() {
+  const { deployer, lp } = accounts();
+  const p = principals();
+  simnet.callPublicFn(REG, "register-market",
+    [Cl.principal(p.borrow), Cl.principal(p.oracle), Cl.uint(1_000_000_000), Cl.uint(0), Cl.uint(0), Cl.uint(2000), Cl.uint(0)], deployer);
+  simnet.callPublicFn(MATRIX, "add-collateral-to-market",
+    [Cl.uint(0), Cl.principal(p.coll), Cl.uint(150), Cl.uint(120), Cl.uint(1000), Cl.uint(100), Cl.uint(1_000_000_000)], deployer);
+  simnet.callPublicFn(MATRIX, "set-collateral-oracle", [Cl.principal(p.coll), Cl.principal(p.oracle)], deployer);
+  // authorize the vault (borrow) and liquidation engine in the pool + registry
+  simnet.callPublicFn(POOL, "set-authorized-caller", [Cl.principal(p.vault), Cl.bool(true)], deployer);
+  simnet.callPublicFn(POOL, "set-authorized-caller", [Cl.principal(p.liq), Cl.bool(true)], deployer);
+  simnet.callPublicFn(REG, "set-authorized-caller", [Cl.principal(p.pool), Cl.bool(true)], deployer);
+  simnet.callPublicFn(REG, "set-authorized-caller", [Cl.principal(p.liq), Cl.bool(true)], deployer);
+  simnet.callPublicFn(VAULT, "set-liquidator", [Cl.principal(p.liq)], deployer);
+  // LP funds the pool
+  mint(BORROW, lp, 100_000);
+  simnet.callPublicFn(POOL, "supply", [Cl.uint(0), borrowCV(), Cl.uint(100_000)], lp);
+}
+
+// alice deposits 1000 sBTC and borrows 600.
+function openPosition() {
+  const { alice } = accounts();
+  mint(COLL, alice, 1000);
+  simnet.callPublicFn(VAULT, "deposit-collateral", [Cl.uint(0), collCV(), collCV(), Cl.uint(1000)], alice);
+  simnet.callPublicFn(VAULT, "borrow", [Cl.uint(0), collCV(), borrowCV(), oracleCV(), Cl.uint(600)], alice);
+}
+
+// Drop the pegged oracle to $0.50 (widen the deviation band first).
+function dropPriceToHalf() {
+  const { deployer } = accounts();
+  simnet.callPublicFn(ORACLE, "set-max-deviation-bps", [Cl.uint(10000)], deployer);
+  simnet.callPublicFn(ORACLE, "set-peg-price", [Cl.uint(50_000_000)], deployer);
+}
+
+const liquidate = (who: string, owner: string) =>
+  simnet.callPublicFn(LIQ, "liquidate", [Cl.principal(owner), Cl.uint(0), collCV(), collCV(), oracleCV()], who);
+
+const positionField = (who: string, field: string): number | null => {
+  const res = simnet.callReadOnlyFn(VAULT, "get-collateral-position", [Cl.principal(who), Cl.uint(0), collCV()], who).result as any;
+  if (res.type === "none") return null;
+  return Number(res.value.value[field].value as bigint);
+};
+const poolUint = (fn: string): number =>
+  Number((simnet.callReadOnlyFn(POOL, fn, [Cl.uint(0)], accounts().deployer).result as any).value as bigint);
+const treasuryAccruedColl = (): number =>
+  Number((simnet.callReadOnlyFn(REG, "get-treasury-accrued", [Cl.uint(0), Cl.principal(principals().coll)], accounts().deployer).result as any).value as bigint);
+const tokenBalance = (token: string, who: string): number =>
+  Number(((simnet.callReadOnlyFn(token, "get-balance", [Cl.principal(who)], accounts().deployer).result as any).value).value as bigint);
+
+describe("liquidation", () => {
+  beforeEach(() => {
+    wire();
+    openPosition();
+  });
+
+  it("reverts on a healthy position", () => {
+    const { keeper, alice } = accounts();
+    // still $1 -> health at liq-ratio 120 = 1000*10000/(600*120) = 138 > 100
+    expect(liquidate(keeper, alice).result).toBeErr(Cl.uint(ERR_POSITION_HEALTHY));
+  });
+
+  it("permissionless trigger settles an unhealthy position; penalty split", () => {
+    const { keeper, alice } = accounts();
+    dropPriceToHalf(); // value 500 -> health 69 < 100
+
+    // base = 600/0.5 = 1200; penalty 10% = 120; want 1320 capped at 1000 collateral.
+    // protocol cut = 120 * 20% = 24; lp = 1000 - 24 = 976.
+    const res = liquidate(keeper, alice).result as any;
+    expect(res.type).toBe("ok");
+    const t = res.value.value;
+    expect(t["debt-written-off"]).toBeUint(600);
+    expect(t["collateral-seized"]).toBeUint(1000);
+    expect(t["protocol-cut"]).toBeUint(24);
+    expect(t["lp-collateral"]).toBeUint(976);
+
+    // position fully cleared
+    expect(positionField(alice, "debt-share")).toBe(0);
+    expect(positionField(alice, "amount")).toBe(0);
+    // pool: debt written off, supplied reduced by the offset
+    expect(poolUint("get-total-borrows")).toBe(0);
+    expect(poolUint("get-total-supplied")).toBe(100_000 - 600);
+    // protocol penalty cut earmarked in treasury-accrued (collateral token)
+    expect(treasuryAccruedColl()).toBe(24);
+    // pool now physically holds the seized collateral
+    expect(tokenBalance(COLL, principals().pool)).toBe(1000);
+
+    // a liquidation record was written
+    expect(
+      Number((simnet.callReadOnlyFn(LIQ, "get-liquidation-count", [], keeper).result as any).value as bigint)
+    ).toBe(1);
+  });
+
+  it("LP can claim the seized collateral after liquidation", () => {
+    const { keeper, alice, lp } = accounts();
+    dropPriceToHalf();
+    liquidate(keeper, alice);
+
+    // sole LP (100k shares) claims the whole lp-collateral (976)
+    const claimable = Number(
+      (simnet.callReadOnlyFn(POOL, "get-claimable-collateral-reward", [Cl.principal(lp), Cl.uint(0), collCV()], lp).result as any).value as bigint
+    );
+    expect(claimable).toBe(976);
+    expect(simnet.callPublicFn(POOL, "claim-collateral-reward", [Cl.uint(0), collCV(), collCV()], lp).result).toBeOk(Cl.uint(976));
+    expect(tokenBalance(COLL, lp)).toBe(976);
+    // 24 remains in the pool for the protocol sweep
+    expect(tokenBalance(COLL, principals().pool)).toBe(24);
+  });
+
+  it("fails closed on oracle mismatch", () => {
+    const { keeper, alice, deployer } = accounts();
+    dropPriceToHalf();
+    // re-point the collateral oracle elsewhere; keeper still passes the pegged one
+    simnet.callPublicFn(MATRIX, "set-collateral-oracle", [Cl.principal(principals().coll), Cl.principal(principals().borrow)], deployer);
+    expect(liquidate(keeper, alice).result).toBeErr(Cl.uint(ERR_ORACLE_MISMATCH));
+  });
+
+  it("reverts when there is no debt position", () => {
+    const { keeper, deployer } = accounts();
+    dropPriceToHalf();
+    // deployer never borrowed
+    expect(liquidate(keeper, deployer).result).toBeErr(Cl.uint(ERR_NO_POSITION));
+  });
+});


### PR DESCRIPTION
Add sse-finance-liquidation-v1 as the liquidation engine (Mechanism A) where any caller can trigger liquidation of unhealthy positions. Validate health-factor < liquidation-ratio via oracle pricing, compute debt-to-offset (capped by pool capacity) and collateral-to-seize (base + penalty capped at available collateral), then settle via vault's new liquidate-position function which reduces position amounts