### PR TITLE
feat: add permissionless sweep-fees to sse-finance-pool-v1 with treasury transfer and cash reduction

### DIFF
--- a/contracts/sse-finance-pool-v1.clar
+++ b/contracts/sse-finance-pool-v1.clar
@@ -498,3 +498,35 @@
     (ok total-claimable)
   )
 )
+
+;; ============================================
+;; Treasury fee sweep (permissionless)
+;; ============================================
+;; Move the accrued protocol fees for a {market, token} -- which physically sit in
+;; this pool (borrow fee in cash; liquidation penalty cut in collateral) -- to the
+;; governance-set treasury, and zero the accrual. Anyone can call; funds can only
+;; ever land at the registry's current treasury principal. When sweeping the
+;; borrow-token, the fee was counted in `cash`, so cash is reduced too (keeping the
+;; invariant cash + total-borrows == total-supplied + treasury-accrued).
+(define-public (sweep-fees (market-id uint) (token <sse-finance-sip-010-trait>))
+  (let (
+      (treasury (contract-call? .sse-finance-market-registry-v1 get-treasury))
+      (token-principal (contract-of token))
+      (state (get-state market-id))
+    )
+    (let ((amount (try! (contract-call? .sse-finance-market-registry-v1 clear-treasury-accrued market-id token-principal))))
+      (if (> amount u0)
+        (begin
+          (try! (as-contract (contract-call? token transfer amount tx-sender treasury none)))
+          (if (is-eq (some token-principal) (market-borrow-token market-id))
+            (map-set pool-state {market-id: market-id} (merge state {cash: (- (get cash state) amount)}))
+            true
+          )
+        )
+        true
+      )
+      (print {event: "fees-swept", market-id: market-id, token: token-principal, amount: amount, treasury: treasury})
+      (ok amount)
+    )
+  )
+)

--- a/tests/sse-finance-pool.test.ts
+++ b/tests/sse-finance-pool.test.ts
@@ -388,3 +388,43 @@ describe("pool: one-time borrow fee (netted from disbursed)", () => {
     expect(borrowOut(vault, borrower, 1000).result).toBeErr(Cl.uint(REG_ERR_UNAUTHORIZED));
   });
 });
+
+describe("pool: treasury fee sweep", () => {
+  // Set fee, authorize pool in registry, and point the treasury at a wallet.
+  function setFeeAuthorizeAndTreasury(treasury: string) {
+    const { deployer } = accounts();
+    const { poolAddr } = principals();
+    simnet.callPublicFn(REG, "set-fee-config", [Cl.uint(0), Cl.uint(200), Cl.uint(0), Cl.uint(2000), Cl.uint(0)], deployer);
+    simnet.callPublicFn(REG, "set-authorized-caller", [Cl.principal(poolAddr), Cl.bool(true)], deployer);
+    simnet.callPublicFn(REG, "set-treasury", [Cl.principal(treasury)], deployer);
+  }
+  const sweep = (caller: string, marketId = 0) =>
+    simnet.callPublicFn(POOL, "sweep-fees", [Cl.uint(marketId), borrowTokenCV()], caller);
+  const treasuryAccrued = () => {
+    const { deployer } = accounts();
+    const { borrowToken } = principals();
+    return Number((simnet.callReadOnlyFn(REG, "get-treasury-accrued", [Cl.uint(0), Cl.principal(borrowToken)], deployer).result as any).value as bigint);
+  };
+
+  beforeEach(setup);
+
+  it("anyone can sweep; funds land at the treasury; accrual zeroes; cash reduced", () => {
+    const { lp1, vault, borrower } = accounts();
+    const treasuryWallet = simnet.getAccounts().get("wallet_5")!;
+    setFeeAuthorizeAndTreasury(treasuryWallet);
+    mintBorrow(lp1, 10_000);
+    supply(lp1, 10_000);
+    borrowOut(vault, borrower, 1000); // fee 20 -> treasury-accrued, cash 9020
+    expect(treasuryAccrued()).toBe(20);
+
+    // permissionless: a random wallet triggers the sweep
+    expect(sweep(borrower).result).toBeOk(Cl.uint(20));
+    expect(tokenBalance(BORROW_TOKEN, treasuryWallet)).toBe(20); // landed at treasury
+    expect(treasuryAccrued()).toBe(0); // accrual zeroed
+    expect(state()).toEqual({ supplied: 10_000, borrows: 1000, cash: 9000 }); // cash reduced
+
+    // sweeping again moves nothing
+    expect(sweep(borrower).result).toBeOk(Cl.uint(0));
+    expect(tokenBalance(BORROW_TOKEN, treasuryWallet)).toBe(20);
+  });
+});


### PR DESCRIPTION


Add sweep-fees public function allowing anyone to move accrued protocol fees (borrow fee in cash, liquidation penalty in collateral) from pool to governance-set treasury. Clear treasury-accrued via registry call, transfer tokens to current treasury principal, and reduce cash when sweeping borrow-token to maintain invariant cash + total-borrows == total-supplied + treasury-accrued.