### PR TITLE
feat: add depeg circuit-breaker to sse-finance-market-registry-v1 with per-market band and vault borrow guard

### DIFF
--- a/contracts/sse-finance-market-registry-v1.clar
+++ b/contracts/sse-finance-market-registry-v1.clar
@@ -32,6 +32,11 @@
 (define-constant MAX-PROTOCOL-LIQ-SHARE u5000)     ;; protocol cut of penalty <= 50%
 (define-constant MAX-EARLY-REPAY u200)             ;; optional early-repay fee <= 2%
 
+;; Depeg circuit-breaker: 8-decimal USD price scale + band cap (bps from $1).
+(define-constant PRICE-SCALE u100000000)
+(define-constant BPS-DENOM u10000)
+(define-constant MAX-DEPEG-BAND u10000)            ;; band <= 100% (keeps lower bound >= 0)
+
 ;; ============================================
 ;; Recorded launch decision (acceptance: explicit, recorded pre-deploy).
 ;; ============================================
@@ -50,6 +55,7 @@
 (define-constant ERR_BOOTSTRAP_LOCKED u801)
 (define-constant ERR_MARKET_NOT_FOUND u802)
 (define-constant ERR_FEE_TOO_HIGH u803)
+(define-constant ERR_INVALID_BAND u804)
 
 ;; ============================================
 ;; Governance (mirrors collateral-registry-v6 / price-oracle-pegged-usd-v1)
@@ -130,6 +136,10 @@
 (define-private (is-authorized-caller)
   (default-to false (map-get? authorized-callers contract-caller))
 )
+
+;; Per-market depeg circuit-breaker band (bps from $1). No row => breaker
+;; disabled for that market (new borrows always allowed by the breaker).
+(define-map depeg-bands {market-id: uint} {band-bps: uint})
 
 ;; ============================================
 ;; Internal validation
@@ -302,6 +312,23 @@
   )
 )
 
+;; ============================================
+;; Depeg circuit-breaker (governance-gated, per market)
+;; ============================================
+
+;; Set a market's depeg band (bps from $1). The market must exist. The vault's
+;; borrow path consults is-within-depeg-band before drawing.
+(define-public (set-depeg-band (market-id uint) (band-bps uint))
+  (begin
+    (asserts! (is-governance-caller) (err ERR_UNAUTHORIZED))
+    (asserts! (is-some (map-get? markets {market-id: market-id})) (err ERR_MARKET_NOT_FOUND))
+    (asserts! (<= band-bps MAX-DEPEG-BAND) (err ERR_INVALID_BAND))
+    (map-set depeg-bands {market-id: market-id} {band-bps: band-bps})
+    (print {event: "depeg-band-set", market-id: market-id, band-bps: band-bps})
+    (ok true)
+  )
+)
+
 ;; Record protocol fee accrual. Called only by an authorized caller (vault/pool),
 ;; not governance -- it runs during normal borrow/liquidate flows.
 (define-public (accrue-fee (market-id uint) (token principal) (amount uint))
@@ -349,6 +376,23 @@
 
 (define-read-only (get-fee-config (market-id uint))
   (map-get? fee-config {market-id: market-id})
+)
+
+(define-read-only (get-depeg-band (market-id uint))
+  (match (map-get? depeg-bands {market-id: market-id}) entry (some (get band-bps entry)) none)
+)
+
+;; True iff the borrow-token price is within the market's depeg band of $1 (or no
+;; band is configured -> always allowed). band-bps is capped at MAX-DEPEG-BAND, so
+;; the lower bound never underflows.
+(define-read-only (is-within-depeg-band (market-id uint) (price uint))
+  (match (map-get? depeg-bands {market-id: market-id})
+    entry
+      (let ((band (/ (* PRICE-SCALE (get band-bps entry)) BPS-DENOM)))
+        (and (>= price (- PRICE-SCALE band)) (<= price (+ PRICE-SCALE band)))
+      )
+    true
+  )
 )
 
 (define-read-only (get-market-count) (var-get market-count))

--- a/contracts/sse-finance-timelock-v1.clar
+++ b/contracts/sse-finance-timelock-v1.clar
@@ -42,6 +42,7 @@
 (define-constant FN-REG-SET-FEE-CONFIG u4)
 (define-constant FN-REG-SET-TREASURY u5)
 (define-constant FN-REG-SET-AUTH u6)
+(define-constant FN-REG-SET-DEPEG u7)
 
 (define-constant FN-MTX-ADD u1)
 (define-constant FN-MTX-UPDATE u2)
@@ -239,6 +240,15 @@
       (compute-hash TARGET-REGISTRY FN-REG-SET-AUTH
         (unwrap-panic (to-consensus-buff? {caller: caller, authorized: authorized})))))
     (as-contract (contract-call? .sse-finance-market-registry-v1 set-authorized-caller caller authorized))
+  )
+)
+
+(define-public (execute-reg-set-depeg-band (id uint) (market-id uint) (band-bps uint))
+  (begin
+    (try! (consume id TARGET-REGISTRY FN-REG-SET-DEPEG
+      (compute-hash TARGET-REGISTRY FN-REG-SET-DEPEG
+        (unwrap-panic (to-consensus-buff? {market-id: market-id, band-bps: band-bps})))))
+    (as-contract (contract-call? .sse-finance-market-registry-v1 set-depeg-band market-id band-bps))
   )
 )
 

--- a/contracts/sse-finance-vault-v1.clar
+++ b/contracts/sse-finance-vault-v1.clar
@@ -42,6 +42,7 @@
 (define-constant ERR_BELOW_DEBT_FLOOR u311)
 (define-constant ERR_BORROW_CAP u312)
 (define-constant ERR_NOT_LIQUIDATOR u313)
+(define-constant ERR_DEPEG u314)
 
 ;; ============================================
 ;; Governance (for the wiring the borrow/liquidation tasks add later)
@@ -280,19 +281,38 @@
 ;; ============================================
 
 ;; Borrow against an existing collateral position. Reverts if the draw would push
-;; the position below the min ratio, over the market's borrow cap, or below the
-;; debt floor. The one-time borrow fee is charged by the pool at draw (netted from
-;; the disbursed amount); the FULL principal `amount` is recorded as flat debt.
+;; the position below the min ratio, over the market's borrow cap, below the debt
+;; floor, OR if the depeg circuit-breaker has tripped (borrow-token price outside
+;; the market's band). The one-time borrow fee is charged by the pool at draw
+;; (netted from the disbursed amount); the FULL principal `amount` is recorded as
+;; flat debt.
+;;
+;; `oracle` prices the COLLATERAL (health); `borrow-oracle` is the market's oracle
+;; pricing the BORROW TOKEN (depeg breaker). Both are validated against their
+;; registered principals and fail closed.
 (define-public (borrow
     (market-id uint)
     (asset principal)
     (borrow-token <sse-finance-sip-010-trait>)
     (oracle <sse-finance-oracle-trait>)
+    (borrow-oracle <sse-finance-oracle-trait>)
     (amount uint)
   )
   (begin
     (asserts! (> amount u0) (err ERR_INVALID_AMOUNT))
     (asserts! (oracle-matches asset oracle) (err ERR_ORACLE_MISMATCH))
+    ;; depeg circuit-breaker: validate the market oracle, price the borrow token,
+    ;; and refuse new borrows when it is outside the market's band
+    (let (
+        (market-oracle (unwrap! (contract-call? .sse-finance-market-registry-v1 get-oracle market-id) (err ERR_ORACLE_MISMATCH)))
+      )
+      (asserts! (is-eq (contract-of borrow-oracle) market-oracle) (err ERR_ORACLE_MISMATCH))
+      (asserts!
+        (contract-call? .sse-finance-market-registry-v1 is-within-depeg-band market-id
+          (unwrap! (contract-call? borrow-oracle get-price) (err ERR_DEPEG)))
+        (err ERR_DEPEG)
+      )
+    )
     (match (map-get? vaults {owner: tx-sender, market-id: market-id})
       vault
         (match (map-get? vault-collateral {owner: tx-sender, market-id: market-id, asset: asset})

--- a/tests/sse-finance-breaker.test.ts
+++ b/tests/sse-finance-breaker.test.ts
@@ -1,0 +1,150 @@
+// Tests for the depeg circuit-breaker: a per-market band (registry) that the
+// vault's borrow path consults. When the borrow-token price is outside the band,
+// NEW borrows revert (ERR_DEPEG) while repay and withdraw still work. The band is
+// per-market and governance-set; one market tripping does not affect another.
+//
+// One pegged oracle serves both the collateral (health) and the borrow-token
+// (breaker). The position is over-collateralised so a price drop trips the
+// breaker without making the position unhealthy.
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+const REG = "sse-finance-market-registry-v1";
+const MATRIX = "sse-finance-collateral-matrix-v1";
+const POOL = "sse-finance-pool-v1";
+const VAULT = "sse-finance-vault-v1";
+const ORACLE = "price-oracle-pegged-usd-v1";
+const BORROW = "vgld-token-v4";
+const COLL = "sbtc-token-v4";
+
+const ERR_ORACLE_MISMATCH = 306;
+const ERR_DEPEG = 314;
+const REG_ERR_UNAUTHORIZED = 800;
+const REG_ERR_MARKET_NOT_FOUND = 802;
+const REG_ERR_INVALID_BAND = 804;
+
+function accounts() {
+  const a = simnet.getAccounts();
+  const deployer = a.get("deployer")!;
+  const lp = a.get("wallet_1")!;
+  const alice = a.get("wallet_2")!;
+  const stranger = a.get("wallet_3")!;
+  return { deployer, lp, alice, stranger };
+}
+function principals() {
+  const { deployer } = accounts();
+  return { borrow: `${deployer}.${BORROW}`, coll: `${deployer}.${COLL}`, oracle: `${deployer}.${ORACLE}`, vault: `${deployer}.${VAULT}`, pool: `${deployer}.${POOL}`, liq: `${deployer}.sse-finance-liquidation-v1` };
+}
+const borrowCV = () => Cl.contractPrincipal(accounts().deployer, BORROW);
+const collCV = () => Cl.contractPrincipal(accounts().deployer, COLL);
+const oracleCV = () => Cl.contractPrincipal(accounts().deployer, ORACLE);
+const mint = (token: string, to: string, amount: number) =>
+  simnet.callPublicFn(token, "faucet-mint", [Cl.uint(amount), Cl.principal(to)], to);
+
+// Register a market, add sBTC collateral + oracle, fund the pool, deposit a big
+// collateral buffer. Returns the market id. Optional band trips the breaker.
+function wireMarket(band?: number): number {
+  const { deployer, lp, alice } = accounts();
+  const p = principals();
+  const reg = simnet.callPublicFn(REG, "register-market",
+    [Cl.principal(p.borrow), Cl.principal(p.oracle), Cl.uint(1_000_000_000), Cl.uint(0), Cl.uint(0), Cl.uint(2000), Cl.uint(0)], deployer);
+  const id = Number((reg.result as any).value.value as bigint);
+  simnet.callPublicFn(MATRIX, "add-collateral-to-market",
+    [Cl.uint(id), Cl.principal(p.coll), Cl.uint(150), Cl.uint(120), Cl.uint(1000), Cl.uint(100), Cl.uint(1_000_000_000)], deployer);
+  simnet.callPublicFn(MATRIX, "set-collateral-oracle", [Cl.principal(p.coll), Cl.principal(p.oracle)], deployer);
+  simnet.callPublicFn(POOL, "set-authorized-caller", [Cl.principal(p.vault), Cl.bool(true)], deployer);
+  if (band !== undefined) {
+    simnet.callPublicFn(REG, "set-depeg-band", [Cl.uint(id), Cl.uint(band)], deployer);
+  }
+  // fund pool + over-collateralise the borrower
+  mint(BORROW, lp, 100_000);
+  simnet.callPublicFn(POOL, "supply", [Cl.uint(id), borrowCV(), Cl.uint(100_000)], lp);
+  mint(COLL, alice, 100_000);
+  simnet.callPublicFn(VAULT, "deposit-collateral", [Cl.uint(id), collCV(), collCV(), Cl.uint(100_000)], alice);
+  return id;
+}
+
+const borrow = (who: string, marketId: number, amount: number, oracle = oracleCV()) =>
+  simnet.callPublicFn(VAULT, "borrow", [Cl.uint(marketId), collCV(), borrowCV(), oracleCV(), oracle, Cl.uint(amount)], who);
+const repay = (who: string, marketId: number, amount: number) =>
+  simnet.callPublicFn(VAULT, "repay", [Cl.uint(marketId), collCV(), borrowCV(), Cl.uint(amount)], who);
+const withdraw = (who: string, marketId: number, amount: number) =>
+  simnet.callPublicFn(VAULT, "withdraw-collateral", [Cl.uint(marketId), collCV(), collCV(), oracleCV(), Cl.uint(amount)], who);
+
+// widen the oracle band then drop the peg to $0.50
+function dropPeg() {
+  const { deployer } = accounts();
+  simnet.callPublicFn(ORACLE, "set-max-deviation-bps", [Cl.uint(10000)], deployer);
+  simnet.callPublicFn(ORACLE, "set-peg-price", [Cl.uint(50_000_000)], deployer);
+}
+
+describe("depeg breaker: borrow guard", () => {
+  beforeEach(() => wireMarket(200)); // 2% band on market 0
+
+  it("allows borrows while the peg holds", () => {
+    const { alice } = accounts();
+    expect(borrow(alice, 0, 600).result).toBeOk(Cl.uint(600));
+  });
+
+  it("blocks NEW borrows when the borrow-token depegs beyond the band", () => {
+    const { alice } = accounts();
+    dropPeg(); // $0.50, outside 2%
+    expect(borrow(alice, 0, 600).result).toBeErr(Cl.uint(ERR_DEPEG));
+  });
+
+  it("repay and withdraw still work while the breaker is tripped", () => {
+    const { alice } = accounts();
+    borrow(alice, 0, 600); // establish debt while healthy
+    dropPeg();
+    // breaker only gates borrow:
+    expect(borrow(alice, 0, 100).result).toBeErr(Cl.uint(ERR_DEPEG));
+    expect(repay(alice, 0, 300).result).toBeOk(Cl.uint(300));
+    expect(withdraw(alice, 0, 1000).result).toBeOk(Cl.uint(99_000));
+  });
+
+  it("fails closed when the borrow-oracle does not match the market oracle", () => {
+    const { alice } = accounts();
+    // pass the collateral token principal as the borrow-oracle -> mismatch
+    expect(borrow(alice, 0, 600, collCV()).result).toBeErr(Cl.uint(ERR_ORACLE_MISMATCH));
+  });
+});
+
+describe("depeg breaker: per-market isolation", () => {
+  it("one market's breaker tripping does not block another market", () => {
+    const { alice } = accounts();
+    const m0 = wireMarket(200); // banded
+    const m1 = wireMarket(); // no band -> breaker disabled
+    dropPeg();
+    expect(borrow(alice, m0, 600).result).toBeErr(Cl.uint(ERR_DEPEG)); // banded market blocked
+    expect(borrow(alice, m1, 600).result).toBeOk(Cl.uint(600)); // other market unaffected
+  });
+});
+
+describe("depeg breaker: governance + validation", () => {
+  beforeEach(() => wireMarket(200));
+
+  it("only governance can set the band", () => {
+    const { stranger } = accounts();
+    expect(simnet.callPublicFn(REG, "set-depeg-band", [Cl.uint(0), Cl.uint(100)], stranger).result)
+      .toBeErr(Cl.uint(REG_ERR_UNAUTHORIZED));
+  });
+
+  it("rejects a band over the cap and an unknown market", () => {
+    const { deployer } = accounts();
+    expect(simnet.callPublicFn(REG, "set-depeg-band", [Cl.uint(0), Cl.uint(10001)], deployer).result)
+      .toBeErr(Cl.uint(REG_ERR_INVALID_BAND));
+    expect(simnet.callPublicFn(REG, "set-depeg-band", [Cl.uint(9), Cl.uint(100)], deployer).result)
+      .toBeErr(Cl.uint(REG_ERR_MARKET_NOT_FOUND));
+  });
+
+  it("get-depeg-band / is-within-depeg-band reflect config", () => {
+    const { deployer } = accounts();
+    expect(simnet.callReadOnlyFn(REG, "get-depeg-band", [Cl.uint(0)], deployer).result).toBeSome(Cl.uint(200));
+    // within 2% of $1
+    expect(simnet.callReadOnlyFn(REG, "is-within-depeg-band", [Cl.uint(0), Cl.uint(101_000_000)], deployer).result).toBeBool(true);
+    expect(simnet.callReadOnlyFn(REG, "is-within-depeg-band", [Cl.uint(0), Cl.uint(103_000_000)], deployer).result).toBeBool(false);
+    // a market with no band configured is always within
+    expect(simnet.callReadOnlyFn(REG, "is-within-depeg-band", [Cl.uint(5), Cl.uint(1)], deployer).result).toBeBool(true);
+  });
+});

--- a/tests/sse-finance-liquidation.test.ts
+++ b/tests/sse-finance-liquidation.test.ts
@@ -73,7 +73,7 @@ function openPosition() {
   const { alice } = accounts();
   mint(COLL, alice, 1000);
   simnet.callPublicFn(VAULT, "deposit-collateral", [Cl.uint(0), collCV(), collCV(), Cl.uint(1000)], alice);
-  simnet.callPublicFn(VAULT, "borrow", [Cl.uint(0), collCV(), borrowCV(), oracleCV(), Cl.uint(600)], alice);
+  simnet.callPublicFn(VAULT, "borrow", [Cl.uint(0), collCV(), borrowCV(), oracleCV(), oracleCV(), Cl.uint(600)], alice);
 }
 
 // Drop the pegged oracle to $0.50 (widen the deviation band first).

--- a/tests/sse-finance-vault-borrow.test.ts
+++ b/tests/sse-finance-vault-borrow.test.ts
@@ -81,7 +81,7 @@ function depositCollateral(amount: number) {
 }
 
 const borrow = (who: string, amount: number) =>
-  simnet.callPublicFn(VAULT, "borrow", [Cl.uint(0), collCV(), borrowCV(), oracleCV(), Cl.uint(amount)], who);
+  simnet.callPublicFn(VAULT, "borrow", [Cl.uint(0), collCV(), borrowCV(), oracleCV(), oracleCV(), Cl.uint(amount)], who);
 const repay = (who: string, amount: number) =>
   simnet.callPublicFn(VAULT, "repay", [Cl.uint(0), collCV(), borrowCV(), Cl.uint(amount)], who);
 


### PR DESCRIPTION

Add depeg circuit-breaker to market-registry-v1 as a per-market band (bps from $1) that the vault's borrow path consults before drawing. When the borrow-token price is outside the band, new borrows revert (ERR_DEPEG) while repay and withdraw still work. Add set-depeg-band governance function with band-bps <= MAX-DEPEG-BAND validation, is-within-depeg-band read-only helper.